### PR TITLE
feat: segment a single frame from the napari viewer

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -39,7 +39,7 @@ jobs:
           python -m unittest
       - name: Test GUI
         run: |
-          python -m pytest tests/gui/
+          python tests/run_gui_tests.py -q
 
   Linux-Minimal:
     name: Linux Minimal
@@ -119,7 +119,7 @@ jobs:
           python -m unittest
       - name: Test GUI
         run: |
-          python -m pytest tests/gui/
+          python tests/run_gui_tests.py -q
 
   Windows-Minimal:
     name: Test Windows Minimal

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -34,12 +34,37 @@ jobs:
       - name: Install package [Full]
         run: |
           pip install ".[all]"
+      # The suite pulls its segmentation/signal models from Zenodo the first
+      # time a test asks for one. Zenodo answers 5xx often enough that an
+      # otherwise good commit fails on it, so keep the downloads between runs:
+      # the key rolls when the tests change, and falls back to the newest
+      # existing cache so a new model is added to it rather than re-fetched
+      # every run.
+      - name: Locate installed package
+        id: pkg
+        shell: bash
+        run: |
+          echo "dir=$(python -c 'import celldetective, os; print(os.path.dirname(os.path.realpath(celldetective.__file__)))')" >> "$GITHUB_OUTPUT"
+      - name: Cache Zenodo models and datasets
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.pkg.outputs.dir }}/models/segmentation_targets
+            ${{ steps.pkg.outputs.dir }}/models/segmentation_effectors
+            ${{ steps.pkg.outputs.dir }}/models/segmentation_generic
+            ${{ steps.pkg.outputs.dir }}/models/segmentation_oocyst
+            ${{ steps.pkg.outputs.dir }}/models/signal_detection
+            ${{ steps.pkg.outputs.dir }}/models/pair_signal_detection
+            ${{ steps.pkg.outputs.dir }}/datasets
+          key: celldetective-zenodo-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('tests/**/*.py') }}
+          restore-keys: |
+            celldetective-zenodo-${{ runner.os }}-py${{ matrix.python-version }}-
       - name: Test package
         run: |
           python -m unittest
       - name: Test GUI
         run: |
-          python tests/run_gui_tests.py -q
+          python tests/run_gui_tests.py
 
   Linux-Minimal:
     name: Linux Minimal
@@ -114,12 +139,37 @@ jobs:
       - name: Install package [Full]
         run: |
           pip install -e ".[all]"
+      # The suite pulls its segmentation/signal models from Zenodo the first
+      # time a test asks for one. Zenodo answers 5xx often enough that an
+      # otherwise good commit fails on it, so keep the downloads between runs:
+      # the key rolls when the tests change, and falls back to the newest
+      # existing cache so a new model is added to it rather than re-fetched
+      # every run.
+      - name: Locate installed package
+        id: pkg
+        shell: bash
+        run: |
+          echo "dir=$(python -c 'import celldetective, os; print(os.path.dirname(os.path.realpath(celldetective.__file__)))')" >> "$GITHUB_OUTPUT"
+      - name: Cache Zenodo models and datasets
+        uses: actions/cache@v4
+        with:
+          path: |
+            ${{ steps.pkg.outputs.dir }}/models/segmentation_targets
+            ${{ steps.pkg.outputs.dir }}/models/segmentation_effectors
+            ${{ steps.pkg.outputs.dir }}/models/segmentation_generic
+            ${{ steps.pkg.outputs.dir }}/models/segmentation_oocyst
+            ${{ steps.pkg.outputs.dir }}/models/signal_detection
+            ${{ steps.pkg.outputs.dir }}/models/pair_signal_detection
+            ${{ steps.pkg.outputs.dir }}/datasets
+          key: celldetective-zenodo-${{ runner.os }}-py${{ matrix.python-version }}-${{ hashFiles('tests/**/*.py') }}
+          restore-keys: |
+            celldetective-zenodo-${{ runner.os }}-py${{ matrix.python-version }}-
       - name: Test package
         run: |
           python -m unittest
       - name: Test GUI
         run: |
-          python tests/run_gui_tests.py -q
+          python tests/run_gui_tests.py
 
   Windows-Minimal:
     name: Test Windows Minimal

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,20 +19,25 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   per-frame halves of `segment()`, so one loaded model can be reused across
   frames that do not arrive as a single stack.
 - `segment()` gained `selected_channels`, `target_cell_size` and `diameter`
-  arguments, which override what the model configuration stores.
+  arguments, which override what the model configuration stores, and
+  `use_stored_mapping`, which opts into what it stores.
 
 ### Changed
-- **`segment()` now honours two settings it used to ignore**, matching what
+- **`segment()` can now honour two settings it used to ignore**, matching what
   `SegmentCellDLProcess` has always done, so the library and the pipeline return
   the same masks for the same model: the `selected_channels` mapping stored in
   the model's `config_input.json`, and the `cell_size_um` /
   `target_cell_size_um` rescaling. Both live in the model directory, which is
-  shared across experiments, so a mapping saved while working on one experiment
-  now also applies to direct `segment()` calls made for another. Pass
-  `selected_channels` / `target_cell_size` explicitly to pin the old behaviour.
+  installed once and shared by every experiment, so applying them by default
+  would let a mapping saved while working on one experiment change the result of
+  a `segment()` call made for another. They are opt-in: pass
+  `use_stored_mapping=True` for pipeline parity, or `selected_channels` /
+  `target_cell_size` to set them explicitly. Existing calls are unaffected.
 - `CUDA_VISIBLE_DEVICES` is now set only while a segmentation model is being
-  built, and restored afterwards, instead of being left pinned for the lifetime
-  of the process.
+  built or run, and restored afterwards, instead of being left pinned for the
+  lifetime of the process. `segment_frame()` re-applies the device choice its
+  model was prepared with, so `use_gpu=False` holds even if the framework defers
+  creating its device context until the first prediction.
 
 ### Fixed
 - Cellpose models could not be loaded at all on Windows: the model name was
@@ -52,6 +57,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   cell onto an existing one.
 - Segmenting a frame from napari can be undone with `Ctrl+Z` like any other edit,
   and reports the number of objects rather than the highest label value.
+- Declining napari's "are you sure you want to close?" prompt no longer takes the
+  frame-segmentation panel down with it. The panel used to tear itself down as
+  soon as the close was *attempted*, leaving a viewer that stayed open with a
+  vanished, permanently inert panel.
+- A model whose download was interrupted no longer shadows the copy on Zenodo
+  forever. `locate_segmentation_model()` skips a local directory that has no
+  `config_input.json`, so the next run re-downloads it instead of failing with
+  "could not be loaded" every time.
+- The frame-segmentation panel builds its channel and parameter rows after a
+  model is fetched on its first run, instead of leaving the "not downloaded yet"
+  placeholder up until the model dropdown is cycled.
+- A cell size of zero is rejected with a message naming the field, rather than
+  failing the run with `float division by zero`.
+- `prepare_segmentation_model()` no longer raises `KeyError` on a Cellpose
+  `config_input.json` that omits `diameter`, `cellprob_threshold` or
+  `flow_threshold` when the caller passes those values explicitly.
 
 ## [1.5.3] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -73,6 +73,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `prepare_segmentation_model()` no longer raises `KeyError` on a Cellpose
   `config_input.json` that omits `diameter`, `cellprob_threshold` or
   `flow_threshold` when the caller passes those values explicitly.
+- A cell size set in the model parameter dialog now reaches the full-position
+  run for a generalist Cellpose model too. The pipeline read the trained size
+  from a `cell_size_um` key those models do not carry, so the setting rescaled
+  the napari preview and `segment()` while the run it was previewing ignored it.
+  All three now go through `trained_cell_size_um()`.
+- Closing the napari viewer during a segmentation run no longer strands the
+  worker thread. Detaching the panel's slots cleared the whole `finished`
+  signal, including the worker's own cleanup, so a run still in flight kept its
+  thread, the image stack and the loaded network alive for the rest of the
+  session.
 
 ## [1.5.3] - 2026-06-04
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,242 @@
+# Changelog
+
+All notable changes to Celldetective are documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Added
+- Segment a single frame straight from the napari correction viewer: a
+  `FrameSegmentationPanel` docked on the right offers model selection, one
+  dropdown per model input slot, and the inference parameters that model type
+  actually takes. The run happens on a worker thread, with progress indication
+  and cancellation, and writes into the `segmentation` layer only - nothing
+  reaches disk until the labels are saved, and nothing is written back to
+  `config_input.json`.
+- `prepare_segmentation_model()` and `segment_frame()` split the setup and
+  per-frame halves of `segment()`, so one loaded model can be reused across
+  frames that do not arrive as a single stack.
+- `segment()` gained `selected_channels`, `target_cell_size` and `diameter`
+  arguments, which override what the model configuration stores.
+
+### Changed
+- **`segment()` now honours two settings it used to ignore**, matching what
+  `SegmentCellDLProcess` has always done, so the library and the pipeline return
+  the same masks for the same model: the `selected_channels` mapping stored in
+  the model's `config_input.json`, and the `cell_size_um` /
+  `target_cell_size_um` rescaling. Both live in the model directory, which is
+  shared across experiments, so a mapping saved while working on one experiment
+  now also applies to direct `segment()` calls made for another. Pass
+  `selected_channels` / `target_cell_size` explicitly to pin the old behaviour.
+- `CUDA_VISIBLE_DEVICES` is now set only while a segmentation model is being
+  built, and restored afterwards, instead of being left pinned for the lifetime
+  of the process.
+
+### Fixed
+- Cellpose models could not be loaded at all on Windows: the model name was
+  derived from the model path with `split("/")[-2]`, which raises `IndexError`
+  on an `os.sep`-joined path.
+- A channel mapping that feeds the same experiment channel into several of a
+  model's input slots no longer leaves all but the first slot black. Channel
+  matching in `segment()` is also consistently case-insensitive now, instead of
+  resolving indices case-insensitively but transferring pixels case-sensitively.
+- Listing the segmentation models no longer deletes model directories or creates
+  category directories as a side effect when it is only being asked what is
+  available.
+- `segment()` no longer crashes when the model cannot be located; it logs and
+  returns None.
+- Labels written into the napari viewer are refused rather than silently wrapped
+  round when they do not fit the layer's integer type, which used to alias a new
+  cell onto an existing one.
+- Segmenting a frame from napari can be undone with `Ctrl+Z` like any other edit,
+  and reports the number of objects rather than the highest label value.
+
+## [1.5.3] - 2026-06-04
+
+This release focuses entirely on window sizing and multi-monitor / high-DPI
+display handling. Previously, windows were sized against the *primary* screen
+and locked with fixed sizes, which left dialogs and panels mis-sized,
+off-screen, or with inaccessible buttons when the app was opened on a secondary
+or scaled display.
+
+### Added
+- New `get_current_screen_geometry()` helper that returns the available
+  geometry of the monitor where the cursor (or the window) actually is, rather
+  than always using the primary screen.
+- High-DPI support: enabled `AA_EnableHighDpiScaling` and `AA_UseHighDpiPixmaps`
+  at startup, so the interface and icons scale correctly on high-DPI / 4K
+  monitors.
+
+### Changed
+- All screen-size lookups now route through `get_current_screen_geometry()`
+  across the app: init window, Control Panel, dynamic progress dialog, settings
+  panels, pivot table view, and the new-experiment configuration dialog.
+- The Control Panel's `screen_width` / `screen_height` are now live properties
+  that re-evaluate against the current screen, so collapsing/expanding panels
+  recomputes against the correct monitor.
+- Windows no longer use `setFixedSize`. They now use sensible minimum sizes plus
+  a resize to a fraction of the current screen, so they remain resizable and
+  adapt to the active display.
+- The Control Panel height is capped at 90% of the current screen, and the cap
+  is re-applied dynamically when the process, preprocessing, and
+  interactions/neighborhood blocks are collapsed/expanded — keeping action
+  buttons reachable on small or scaled screens.
+- Annotators and the threshold configuration wizard (`BaseAnnotator`,
+  `PairEventAnnotator`, `ThresholdConfigWizard`) now use fixed minimum sizes
+  (e.g. 800×600) and resize to 80% of the current screen instead of forcing an
+  80%-of-primary-screen minimum.
+- The new-experiment condition-labels dialog uses a fixed minimum width and
+  resizes to a screen-relative width.
+- The init window now uses `setMinimumSize(sizeHint())` instead of a fixed size,
+  allowing it to grow when needed.
+
+## [1.5.2] - 2026-05-03
+
+This release adds several new cell measurements, rewrites the custom-measurement
+API documentation, and includes a large robustness pass (the "Claude audit"):
+silent failures were removed, `print` calls converted to proper logging,
+`assert`s replaced with explicit exceptions, and numerous edge cases hardened.
+
+### Added
+- New shape measurements: `circularity` (4π·area / perimeter²) and
+  `aspect_ratio` (major axis / minor axis), both produced as single scalar
+  columns with no channel suffix.
+- New per-channel intensity distribution moments: `intensity_skewness` and
+  `intensity_kurtosis` (Fisher / excess).
+- Mask contact-site intensity measurement and accompanying tests.
+- Membrane-to-cytoplasm (M/C) intensity ratio measurement.
+- Custom-measurement API now supports three signatures (shape-only,
+  per-channel intensity, and single-`target_channel` intensity), documented in
+  the "write a custom measurement" guide.
+- New `regionprops` reference page in the documentation.
+- New test suites: contact-site intensity and extra-properties (including the
+  new measurement GUI).
+
+### Changed
+- Centralized `COLUMN_LABELS` and aligned feature definitions with the code.
+- Converted `print` statements to structured logging and replaced `assert`s
+  with explicit, descriptive exceptions across the codebase.
+- Replaced `os.abort` with `sys.exit` for clean shutdown.
+- btrack pinned to `>=0.5.13,<0.8`, and btrack logs are now surfaced to the
+  user.
+
+### Fixed
+- Relative-measurements indexing bug, plus bugs in pair, intersection, and
+  contact-site measurements.
+- Center-of-mass displacement calculation.
+- Neighborhood column detection.
+- `StackVisualizer` threading regression and intertwined-animation bug when
+  resizing the event-annotation window.
+- Channel-index handling and a Windows access-violation error.
+- Robustness safety nets: torch unavailable, empty channel list, imageio
+  versions that mishandle array-type frame indices, and uninitialized
+  variables.
+
+## [1.5.1] - 2026-03-28
+
+Adds a suite of interactive table-derived plots and binned-data visualization,
+plus a round of bug fixes.
+
+### Added
+- **Histogram in the measurement annotator** for quick data inspection.
+- **Binned data and binned plots** — group data into bins with dedicated plot
+  support for visualizing binned distributions.
+- **Parallel-coordinates plot** for multi-dimensional data exploration in the
+  table UI.
+- **Correlation plot** — correlation matrix for pairwise relationships between
+  measurements.
+- **Interactive plots from the table** — table-derived plots are now
+  interactive, and statistical results (p-values, effect sizes) can be
+  exported.
+- **Visual selector for plots** with improved colormap behavior.
+- **More intuitive 2D plotting** — improved histogram and KDE interactions in
+  the table UI.
+- Settings windows now enforce a minimum width to prevent layout issues on
+  small screens.
+
+### Fixed
+- Empty-dataframe crash when no cells are detected on a given frame.
+- Styling inconsistencies in the correlation-matrix and parallel-coordinates
+  windows.
+- Empty-table bug when opening neighborhood settings ([#21]).
+- Cellpose model-parameter dialog bug ([#22]).
+- Measurement bug ([#23]).
+- Empty-table handling, via a shared helper function deployed across all
+  relevant widgets.
+- Crash when opening the pair annotator on untracked data.
+- Diameter type-coercion bug (int/float).
+- Classifier-widget behavior.
+- Tracking bug.
+- Linux floating-point precision bug.
+- `groupby` bug on track collapse.
+- Progress-bar time estimation for reversed-frame segmentation.
+
+### Documentation
+- Switched to a card-based documentation portal.
+- Renamed the "Pair Event Annotator" to **Interaction Annotator** and the
+  "Static Measurements Annotator" to **Phenotype Annotator**.
+- Documented the multi-threshold segmentation pipeline and the OR operation
+  for mask union.
+
+## [1.5.0] - 2026-02-12
+
+A major feature release: progress feedback throughout the pipeline, optional
+heavy dependencies, faster startup, a reorganized processing UI, and a large
+documentation and test overhaul.
+
+### Added
+- **Progress bars across the pipeline:** neighborhood computation, background
+  correction and preprocessing, tracking, and downloads (demos / models /
+  datasets), plus a generic download progress window and an advanced
+  stack-loader bar.
+- **Live training feedback:** training loss and plots shown directly in the
+  progress popup.
+- **Viewer improvements:** framerate slider, next/previous-frame buttons,
+  interactive time-series integration in the event viewer, and an improved spot
+  detection viewer.
+- Edit the config file directly from within Celldetective.
+- Non-blocking napari with a load progress dialog for annotation correction,
+  and stylized napari buttons.
+- Freeze U-Net layers for more efficient transfer learning; model-fit preview
+  on a single image.
+- Recent-projects list capped at the last 10.
+
+### Changed
+- **Optional heavy dependencies:** TensorFlow, StarDist, and Cellpose are now
+  optional, with graceful fallbacks and partial-install support; clearer
+  messages when StarDist/torch are missing.
+- **Faster startup** via lazy TensorFlow imports and lightened startup-window
+  imports.
+- Split the monolithic `process_block` into separate `interactions_block`,
+  `preprocessing_block`, and `process_block` panels.
+- Major refactor of the measure annotator and edge/stack visualizers; renamed
+  the Cellpose/StarDist submodules to reduce confusion.
+- Migrated `|` type hints to `Union` and added function typing throughout, with
+  auto-generated typing from docstrings in the docs.
+
+### Fixed
+- Interactions-table and contour-viewer (incl. local correction) bugs.
+- Spot-detection measurement bugs and channel-offset viewer bugs.
+- GPU selected while torch is not configured for it.
+- Tracking: interpolate time gaps, group-by tracks, and progress when masks are
+  missing/empty.
+- Circular-import issues with napari and TableUI.
+- Keras-version MSE bug and a Windows-specific pretrained-event-model bug;
+  Zenodo download path issue.
+
+### Tests / CI
+- Large expansion of the GUI and unit test suites (table UI, thresholds,
+  survival UI, viewers, segmentation model loader, settings panels, partial
+  install, image formats, and more).
+- Resolved Windows access-violation, hanging, and stalling test issues; build
+  the package on tag and fix the PyPI workflow.
+
+[1.5.3]: https://github.com/celldetective/celldetective/compare/v1.5.2...v1.5.3
+[1.5.2]: https://github.com/celldetective/celldetective/compare/v1.5.1...v1.5.2
+[1.5.1]: https://github.com/celldetective/celldetective/compare/v1.5.0...v1.5.1
+[1.5.0]: https://github.com/celldetective/celldetective/compare/v1.4.3...v1.5.0
+[#21]: https://github.com/celldetective/celldetective/issues/21
+[#22]: https://github.com/celldetective/celldetective/issues/22
+[#23]: https://github.com/celldetective/celldetective/issues/23

--- a/celldetective/gui/base/figure_canvas.py
+++ b/celldetective/gui/base/figure_canvas.py
@@ -12,6 +12,65 @@ from celldetective import get_logger
 logger = get_logger(__name__)
 
 
+_SAFE_CANVAS_CLS = None
+
+
+def _safe_canvas_class():
+    """
+    Return a ``FigureCanvasQTAgg`` subclass whose paint cannot fault the process.
+
+    matplotlib's ``paintEvent`` opens ``QPainter(self)`` and then, without
+    checking that it actually started, calls ``painter.eraseRect(rect)``.
+    ``QPainter::eraseRect()`` is one of the few QPainter methods that reads
+    ``d->state`` with no active-painter guard, so when ``begin()`` fails the
+    call dereferences a null pointer and the interpreter dies with
+    "Windows fatal exception: access violation" -- no traceback, no failing
+    assertion, the whole process gone.
+
+    ``begin()`` fails whenever the widget has no usable paint engine: a zero
+    width or height, a backing store already torn down with the window, or a
+    paint that re-enters while another painter is still open on the widget.
+    Those all happen while a viewer is being closed or resized, and a paint
+    that could not begin would have drawn nothing anyway -- so probe the paint
+    device first and skip the paint instead of faulting on it.
+
+    The class is built lazily so importing this module does not pull in the Qt
+    backend before a figure is actually needed.
+    """
+
+    global _SAFE_CANVAS_CLS
+    if _SAFE_CANVAS_CLS is not None:
+        return _SAFE_CANVAS_CLS
+
+    from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+    from PyQt5.QtGui import QPainter
+
+    class SafeFigureCanvasQTAgg(FigureCanvasQTAgg):
+        """FigureCanvasQTAgg that no-ops a paint it cannot safely perform."""
+
+        def paintEvent(self, event):
+            if self.width() <= 0 or self.height() <= 0:
+                return
+
+            # Ask Qt the same question matplotlib's paintEvent fails to ask.
+            probe = QPainter()
+            if not probe.begin(self):
+                logger.debug(
+                    "Skipping canvas paint: no paint engine available "
+                    "(size=%sx%s, visible=%s).",
+                    self.width(),
+                    self.height(),
+                    self.isVisible(),
+                )
+                return
+            probe.end()
+
+            super().paintEvent(event)
+
+    _SAFE_CANVAS_CLS = SafeFigureCanvasQTAgg
+    return _SAFE_CANVAS_CLS
+
+
 class FigureCanvas(CelldetectiveWidget):
     """
     Generic figure canvas.
@@ -40,9 +99,7 @@ class FigureCanvas(CelldetectiveWidget):
         super().__init__()
         self.fig = fig
         self.setWindowTitle(title)
-        from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
-
-        self.canvas = FigureCanvasQTAgg(self.fig)
+        self.canvas = _safe_canvas_class()(self.fig)
         self.canvas.setStyleSheet("background-color: transparent;")
         if interactive:
             from matplotlib.backends.backend_qt5agg import NavigationToolbar2QT
@@ -98,6 +155,16 @@ class FigureCanvas(CelldetectiveWidget):
         event : QCloseEvent
             The close event.
         """
+        # Silence the canvas before the figure goes. WA_DeleteOnClose only
+        # *schedules* deletion, so Qt can still deliver a paint between here
+        # and the deleteLater(), and that paint would run against a figure
+        # that no longer has any axes on a window that is already going away.
+        try:
+            self.canvas.setUpdatesEnabled(False)
+            self.canvas.hide()
+        except RuntimeError as e:
+            logger.debug(f"Canvas already destroyed during cleanup: {e}")
+
         self.fig.clf()
         plt.close(self.fig)
         super(FigureCanvas, self).closeEvent(event)

--- a/celldetective/gui/base/figure_canvas.py
+++ b/celldetective/gui/base/figure_canvas.py
@@ -17,22 +17,28 @@ _SAFE_CANVAS_CLS = None
 
 def _safe_canvas_class():
     """
-    Return a ``FigureCanvasQTAgg`` subclass whose paint cannot fault the process.
+    Return a ``FigureCanvasQTAgg`` subclass that cannot kill the interpreter.
 
-    matplotlib's ``paintEvent`` opens ``QPainter(self)`` and then, without
-    checking that it actually started, calls ``painter.eraseRect(rect)``.
-    ``QPainter::eraseRect()`` is one of the few QPainter methods that reads
-    ``d->state`` with no active-painter guard, so when ``begin()`` fails the
-    call dereferences a null pointer and the interpreter dies with
-    "Windows fatal exception: access violation" -- no traceback, no failing
-    assertion, the whole process gone.
+    Qt keeps delivering paints and queued idle-draws to a canvas that is on its
+    way out -- a window mid-close, a widget whose C++ half sip has already
+    freed, a layout that has left it zero-sized. matplotlib's handlers assume
+    none of that:
 
-    ``begin()`` fails whenever the widget has no usable paint engine: a zero
-    width or height, a backing store already torn down with the window, or a
-    paint that re-enters while another painter is still open on the widget.
-    Those all happen while a viewer is being closed or resized, and a paint
-    that could not begin would have drawn nothing anyway -- so probe the paint
-    device first and skip the paint instead of faulting on it.
+    * ``paintEvent`` opens ``QPainter(self)`` and then calls
+      ``painter.eraseRect(rect)`` without checking that ``begin()`` succeeded.
+      ``QPainter::eraseRect()`` reads ``d->state`` with no active-painter
+      guard, so a painter that failed to begin is a null dereference and the
+      process dies with "Windows fatal exception: access violation".
+    * both ``paintEvent`` and ``_draw_idle`` -- the latter reached from a
+      ``QTimer.singleShot`` that outlives the widget it was armed for -- touch
+      the C++ object outside any try block. Once sip has freed it that is a
+      ``RuntimeError`` raised inside a Qt handler, and PyQt5 answers an
+      unhandled exception in a virtual with ``abort()``.
+
+    Either way the process dies with no traceback and no failing assertion,
+    taking the whole run's results with it. A paint that cannot begin would
+    have drawn nothing anyway, so check the cheap, side-effect-free conditions
+    up front and swallow the deletion race that is left.
 
     The class is built lazily so importing this module does not pull in the Qt
     backend before a figure is actually needed.
@@ -43,29 +49,39 @@ def _safe_canvas_class():
         return _SAFE_CANVAS_CLS
 
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
-    from PyQt5.QtGui import QPainter
+    from PyQt5 import sip
 
     class SafeFigureCanvasQTAgg(FigureCanvasQTAgg):
-        """FigureCanvasQTAgg that no-ops a paint it cannot safely perform."""
+        """FigureCanvasQTAgg that no-ops a draw it cannot safely perform."""
+
+        def _is_paintable(self):
+            """Whether drawing this canvas can touch Qt at all."""
+
+            # Ask sip before Qt: every other call here goes through the
+            # wrapper, and on a freed object that is the RuntimeError we are
+            # trying to avoid rather than an answer.
+            if sip.isdeleted(self):
+                return False
+            return self.isVisible() and self.width() > 0 and self.height() > 0
 
         def paintEvent(self, event):
-            if self.width() <= 0 or self.height() <= 0:
+            if not self._is_paintable():
                 return
+            try:
+                super().paintEvent(event)
+            except RuntimeError as e:
+                # Freed between the check above and the paint itself.
+                logger.debug(f"Skipped paint on a canvas being destroyed: {e}")
 
-            # Ask Qt the same question matplotlib's paintEvent fails to ask.
-            probe = QPainter()
-            if not probe.begin(self):
-                logger.debug(
-                    "Skipping canvas paint: no paint engine available "
-                    "(size=%sx%s, visible=%s).",
-                    self.width(),
-                    self.height(),
-                    self.isVisible(),
-                )
+        def _draw_idle(self):
+            # Armed by QTimer.singleShot(0, self._draw_idle); the widget can be
+            # gone by the time it fires.
+            if sip.isdeleted(self):
                 return
-            probe.end()
-
-            super().paintEvent(event)
+            try:
+                super()._draw_idle()
+            except RuntimeError as e:
+                logger.debug(f"Skipped idle draw on a canvas being destroyed: {e}")
 
     _SAFE_CANVAS_CLS = SafeFigureCanvasQTAgg
     return _SAFE_CANVAS_CLS

--- a/celldetective/gui/base/figure_canvas.py
+++ b/celldetective/gui/base/figure_canvas.py
@@ -103,7 +103,14 @@ def _safe_canvas_class():
                     buf = memoryview(
                         self.copy_from_bbox(Bbox([[left, bottom], [right, top]]))
                     )
-                    painter.eraseRect(rect)
+                    # matplotlib calls painter.eraseRect(rect) here.
+                    # QPainter::eraseRect() is fillRect(r, background()), and
+                    # both eraseRect and background() read d->state with no
+                    # active-painter guard, so on a painter that did not begin
+                    # they are a null dereference rather than a no-op.
+                    # fillRect() checks d->engine first, so name the brush
+                    # ourselves and go through the guarded path instead.
+                    painter.fillRect(rect, self.palette().window())
                     qimage = QImage(
                         buf, buf.shape[1], buf.shape[0], QImage.Format_RGBA8888
                     )

--- a/celldetective/gui/base/figure_canvas.py
+++ b/celldetective/gui/base/figure_canvas.py
@@ -19,26 +19,29 @@ def _safe_canvas_class():
     """
     Return a ``FigureCanvasQTAgg`` subclass that cannot kill the interpreter.
 
-    Qt keeps delivering paints and queued idle-draws to a canvas that is on its
-    way out -- a window mid-close, a widget whose C++ half sip has already
-    freed, a layout that has left it zero-sized. matplotlib's handlers assume
-    none of that:
+    Qt keeps delivering paints and queued idle-draws to a canvas that is in no
+    state to serve them -- a window mid-close, a widget whose C++ half sip has
+    already freed, one shown on a CI session that never composites it.
+    matplotlib's handlers assume none of that:
 
     * ``paintEvent`` opens ``QPainter(self)`` and then calls
       ``painter.eraseRect(rect)`` without checking that ``begin()`` succeeded.
-      ``QPainter::eraseRect()`` reads ``d->state`` with no active-painter
-      guard, so a painter that failed to begin is a null dereference and the
-      process dies with "Windows fatal exception: access violation".
-    * both ``paintEvent`` and ``_draw_idle`` -- the latter reached from a
+      ``QPainter::eraseRect()`` is one of the few QPainter methods that reads
+      ``d->state`` with no active-painter guard, so a painter that failed to
+      begin is a null dereference: "Windows fatal exception: access violation",
+      no traceback, no failing assertion, the whole run's results gone.
+    * ``paintEvent`` and ``_draw_idle`` -- the latter reached from a
       ``QTimer.singleShot`` that outlives the widget it was armed for -- touch
       the C++ object outside any try block. Once sip has freed it that is a
-      ``RuntimeError`` raised inside a Qt handler, and PyQt5 answers an
-      unhandled exception in a virtual with ``abort()``.
+      ``RuntimeError`` raised inside a Qt virtual, which PyQt5 answers with
+      ``abort()``.
 
-    Either way the process dies with no traceback and no failing assertion,
-    taking the whole run's results with it. A paint that cannot begin would
-    have drawn nothing anyway, so check the cheap, side-effect-free conditions
-    up front and swallow the deletion race that is left.
+    Whether ``begin()`` will succeed cannot be predicted from the widget's
+    visibility or size -- a live, visible, non-zero-sized canvas can still have
+    no paint engine. The only reliable answer is the painter itself, so open
+    one, ask it, and drive the draw from it. That is matplotlib's own paint
+    body with the missing guard added, rather than a second painter opened
+    behind its back.
 
     The class is built lazily so importing this module does not pull in the Qt
     backend before a figure is actually needed.
@@ -49,26 +52,70 @@ def _safe_canvas_class():
         return _SAFE_CANVAS_CLS
 
     from matplotlib.backends.backend_qt5agg import FigureCanvasQTAgg
+    from matplotlib.transforms import Bbox
     from PyQt5 import sip
+    from PyQt5.QtCore import QPoint
+    from PyQt5.QtGui import QImage, QPainter
 
     class SafeFigureCanvasQTAgg(FigureCanvasQTAgg):
         """FigureCanvasQTAgg that no-ops a draw it cannot safely perform."""
 
-        def _is_paintable(self):
-            """Whether drawing this canvas can touch Qt at all."""
-
+        def paintEvent(self, event):
             # Ask sip before Qt: every other call here goes through the
             # wrapper, and on a freed object that is the RuntimeError we are
             # trying to avoid rather than an answer.
             if sip.isdeleted(self):
-                return False
-            return self.isVisible() and self.width() > 0 and self.height() > 0
-
-        def paintEvent(self, event):
-            if not self._is_paintable():
                 return
+
             try:
-                super().paintEvent(event)
+                self._draw_idle()  # Only does something if a draw is pending.
+
+                # No renderer yet: give up and wait for the first real draw,
+                # exactly as matplotlib does.
+                if not hasattr(self, "renderer"):
+                    return
+
+                painter = QPainter(self)
+                if not painter.isActive():
+                    # begin() failed -- no paint engine on this device. This is
+                    # the case matplotlib walks straight into.
+                    logger.debug(
+                        "Skipped canvas paint: no paint engine "
+                        f"(size={self.width()}x{self.height()}, "
+                        f"visible={self.isVisible()})."
+                    )
+                    return
+
+                try:
+                    # See documentation of QRect: bottom() and right() are off
+                    # by 1, so use left() + width() and top() + height().
+                    rect = event.rect()
+                    # Scale the rect by the screen dpi ratio to get Figure
+                    # coordinates rather than Qt ones.
+                    width = rect.width() * self.device_pixel_ratio
+                    height = rect.height() * self.device_pixel_ratio
+                    left, top = self.mouseEventCoords(rect.topLeft())
+                    # Shift "top" by the image height, and "left" by its width,
+                    # to reach the corners in our coordinate system.
+                    bottom = top - height
+                    right = left + width
+
+                    buf = memoryview(
+                        self.copy_from_bbox(Bbox([[left, bottom], [right, top]]))
+                    )
+                    painter.eraseRect(rect)
+                    qimage = QImage(
+                        buf, buf.shape[1], buf.shape[0], QImage.Format_RGBA8888
+                    )
+                    qimage.setDevicePixelRatio(self.device_pixel_ratio)
+                    painter.drawImage(QPoint(rect.left(), rect.top()), qimage)
+
+                    # The rubber band the zoom tool draws over the figure.
+                    draw_rect = getattr(self, "_draw_rect_callback", None)
+                    if draw_rect is not None:
+                        draw_rect(painter)
+                finally:
+                    painter.end()
             except RuntimeError as e:
                 # Freed between the check above and the paint itself.
                 logger.debug(f"Skipped paint on a canvas being destroyed: {e}")

--- a/celldetective/gui/base/model_channel_selection.py
+++ b/celldetective/gui/base/model_channel_selection.py
@@ -1,0 +1,180 @@
+"""
+The channel-selection rows shared by every place a model's inputs are mapped.
+
+A deep-learning model declares the inputs it was trained on -- ``brightfield``,
+``live_nuclei``, ... -- and the experiment has channels of its own, named by
+whoever acquired them. Mapping one onto the other is the same job whether it is
+done in the main window before a full-stack run or in the napari viewer on a
+single frame, so it is done here once.
+"""
+
+from typing import List, Optional, Sequence
+
+from PyQt5.QtCore import Qt
+from PyQt5.QtWidgets import QComboBox, QHBoxLayout, QLabel, QVBoxLayout, QWidget
+
+from celldetective.gui.base.components import CelldetectiveWidget
+
+#: What an unused input slot is called, in the dropdowns and in the
+#: ``selected_channels`` mapping written to a model's ``config_input.json``.
+NO_CHANNEL = "None"
+
+
+class ModelChannelSelection(CelldetectiveWidget):
+    """
+    One dropdown per model input slot, listing the experiment's channels.
+
+    The rows are seeded in decreasing order of specificity: the mapping already
+    chosen for this model, then a plain name match between the slot and an
+    experiment channel, then :data:`NO_CHANNEL`. Nothing is written anywhere --
+    the widget only reports what is selected, and the caller decides whether that
+    is worth persisting.
+
+    Parameters
+    ----------
+    required_channels : sequence of str
+        The model's input slots, in the order it expects them, as read from the
+        ``channels`` entry of its ``config_input.json``.
+    available_channels : sequence of str
+        The experiment's channel names.
+    selected_channels : sequence of str, optional
+        A mapping to seed the dropdowns with, typically the ``selected_channels``
+        entry of the model configuration. Entries that do not name an available
+        channel are ignored, one by one, so a stale mapping degrades to a name
+        match rather than being dropped whole.
+    show_requirement : bool, optional
+        Whether to print the slot the dropdown feeds above it. True by default.
+    parent : QWidget, optional
+        The parent widget.
+
+    Attributes
+    ----------
+    channel_cbs : list of QComboBox
+        The dropdowns, one per input slot, in the model's own order.
+    """
+
+    def __init__(
+        self,
+        required_channels: Sequence[str],
+        available_channels: Sequence[str],
+        selected_channels: Optional[Sequence[str]] = None,
+        show_requirement: bool = True,
+        parent: Optional[QWidget] = None,
+    ) -> None:
+
+        super().__init__(parent)
+
+        self.required_channels = [str(c) for c in (required_channels or [])]
+        self.available_channels = [str(c) for c in (available_channels or [])]
+        self.show_requirement = show_requirement
+        self.options = self.available_channels + [NO_CHANNEL]
+        self.channel_cbs: List[QComboBox] = []
+
+        self.channel_layout = QVBoxLayout(self)
+        self.channel_layout.setContentsMargins(0, 0, 0, 0)
+        self.populate_widgets(selected_channels)
+
+    def populate_widgets(self, selected_channels: Optional[Sequence[str]]) -> None:
+        """
+        Build one row per input slot.
+
+        Parameters
+        ----------
+        selected_channels : sequence of str or None
+            The mapping to seed the dropdowns with.
+        """
+
+        if not self.required_channels:
+            self.channel_layout.addWidget(
+                QLabel("This model declares no input channels.")
+            )
+            return
+
+        for k, slot in enumerate(self.required_channels):
+
+            combo = QComboBox()
+            combo.addItems(self.options)
+            combo.setToolTip(f"Feeds the model's '{slot}' input.")
+            combo.setCurrentIndex(
+                self._default_index(combo, slot, selected_channels, k)
+            )
+            self.channel_cbs.append(combo)
+
+            hbox_channel = QHBoxLayout()
+            hbox_channel.addWidget(QLabel(f"channel {k+1}: "), 33)
+            if self.show_requirement:
+                ch_vbox = QVBoxLayout()
+                ch_vbox.addWidget(QLabel(f"Req: {slot}"), alignment=Qt.AlignLeft)
+                ch_vbox.addWidget(combo)
+                hbox_channel.addLayout(ch_vbox, 66)
+            else:
+                hbox_channel.addWidget(combo, 66)
+            self.channel_layout.addLayout(hbox_channel)
+
+    def _default_index(
+        self,
+        combo: QComboBox,
+        slot: str,
+        selected_channels: Optional[Sequence[str]],
+        k: int,
+    ) -> int:
+        """
+        Pick the option a slot opens on.
+
+        Parameters
+        ----------
+        combo : QComboBox
+            The dropdown being seeded, already filled with :attr:`options`.
+        slot : str
+            The input slot this dropdown feeds.
+        selected_channels : sequence of str or None
+            The mapping to prefer, when it names an available channel.
+        k : int
+            Position of the slot in the model's input list.
+
+        Returns
+        -------
+        int
+            Index of the option to select. Never negative: :data:`NO_CHANNEL` is
+            always among the options, so there is always something to fall back
+            on.
+        """
+
+        if selected_channels is not None and k < len(selected_channels):
+            idx = combo.findText(str(selected_channels[k]))
+            if idx >= 0:
+                return idx
+
+        idx = combo.findText(slot)
+        if idx >= 0:
+            return idx
+
+        return combo.findText(NO_CHANNEL)
+
+    def selected_channels(self) -> List[str]:
+        """
+        The mapping as it currently stands.
+
+        Returns
+        -------
+        list of str
+            One experiment channel name -- or :data:`NO_CHANNEL` -- per input
+            slot, in the model's own order. Empty when the model declares no
+            inputs.
+        """
+
+        return [combo.currentText() for combo in self.channel_cbs]
+
+    def is_empty(self) -> bool:
+        """
+        Whether every input slot is left unassigned.
+
+        Returns
+        -------
+        bool
+            True when there is at least one slot and none of them is fed by an
+            experiment channel, which no model can be run on.
+        """
+
+        selected = self.selected_channels()
+        return bool(selected) and all(ch == NO_CHANNEL for ch in selected)

--- a/celldetective/gui/base/utils.py
+++ b/celldetective/gui/base/utils.py
@@ -66,3 +66,30 @@ def pretty_table(dct: dict):
     table.add_row([dct.get(c, "") for c in dct.keys()])
     logger.debug(str(table))
 
+
+
+def flush_layout_events(widget: QWidget) -> None:
+    """
+    Settle a widget's own pending layout events, without running the event loop.
+
+    The replacement for a ``QApplication.processEvents()`` at the end of a
+    ``populate_*`` / ``_build_layouts`` / ``__init__``. That call was only ever
+    meant to let the window lay itself out before the next line measured it, but
+    it re-enters the event loop with the widget half-built and dispatches
+    *everything* that happens to be queued -- including the ``DeferredDelete`` of
+    any window closed earlier. Qt frees those C++ objects while events queued
+    behind the deletion are still addressed to them, and delivering one of those
+    is an access violation attributed to whatever is on the stack at the time.
+
+    ``sendPostedEvents`` restricted to `widget` does the useful half only: it
+    delivers this widget's and its children's posted events, and Qt excludes
+    ``DeferredDelete`` from it unless that type is asked for by name, so nothing
+    can be destroyed underneath the caller.
+
+    Parameters
+    ----------
+    widget : QWidget
+        The widget whose pending events should be delivered.
+    """
+
+    QApplication.sendPostedEvents(widget, 0)

--- a/celldetective/gui/base/utils.py
+++ b/celldetective/gui/base/utils.py
@@ -95,6 +95,45 @@ def flush_layout_events(widget: QWidget) -> None:
     QApplication.sendPostedEvents(widget, 0)
 
 
+_SIP_MODULES = None
+
+
+def _sip_modules() -> tuple:
+    """
+    The sip modules that might own a Qt wrapper, most likely first.
+
+    PyQt5 wraps its objects with the ``PyQt5.sip`` module it was built against.
+    A top-level ``sip`` module is a different build -- conda ships one, and it is
+    importable alongside a pip-installed PyQt5 -- whose ``isdeleted`` rejects
+    foreign wrappers outright. Trying the bundled module first means the common
+    case never depends on that rejection being handled.
+
+    Returns
+    -------
+    tuple
+        The importable sip modules, in the order they should be tried.
+    """
+
+    global _SIP_MODULES
+    if _SIP_MODULES is None:
+        modules = []
+        try:
+            from PyQt5 import sip as pyqt5_sip
+
+            modules.append(pyqt5_sip)
+        except ImportError:
+            pass
+        try:
+            import sip as top_level_sip
+
+            if top_level_sip not in modules:
+                modules.append(top_level_sip)
+        except ImportError:
+            pass
+        _SIP_MODULES = tuple(modules)
+    return _SIP_MODULES
+
+
 def is_alive(obj) -> bool:
     """
     Whether a Qt object's underlying C++ object is still there.
@@ -105,6 +144,11 @@ def is_alive(obj) -> bool:
     sometimes a clean ``RuntimeError`` -- but when the deletion was partial, a
     parent still standing with its children freed, it is an access violation
     instead, which no ``except`` can catch. Asking first is the only guard.
+
+    When no sip module can answer -- none importable, or none that recognises
+    the wrapper -- this returns True. The guard is then no worse than the
+    unguarded code it replaced, whereas a False would silently disable whatever
+    it protects on an environment that is otherwise perfectly healthy.
 
     Parameters
     ----------
@@ -119,16 +163,17 @@ def is_alive(obj) -> bool:
 
     if obj is None:
         return False
-    try:
-        import sip
 
-        return not sip.isdeleted(obj)
-    except ImportError:
+    for module in _sip_modules():
         try:
-            from PyQt5 import sip as _sip
-
-            return not _sip.isdeleted(_sip.cast(obj, type(obj)) if False else obj)
-        except Exception:
-            return True
-    except (TypeError, RuntimeError):
-        return False
+            return not module.isdeleted(obj)
+        except TypeError:
+            # Wrong sip build for this wrapper -- it cannot see the object at
+            # all, which says nothing about whether the object is alive. Ask the
+            # next one rather than reporting a live widget dead: every caller
+            # here uses a False to skip an update, so guessing wrong loses a
+            # slider sync or a redraw with nothing logged.
+            continue
+        except RuntimeError:
+            return False
+    return True

--- a/celldetective/gui/base/utils.py
+++ b/celldetective/gui/base/utils.py
@@ -93,3 +93,42 @@ def flush_layout_events(widget: QWidget) -> None:
     """
 
     QApplication.sendPostedEvents(widget, 0)
+
+
+def is_alive(obj) -> bool:
+    """
+    Whether a Qt object's underlying C++ object is still there.
+
+    A Python wrapper outlives the object it wraps: every window here carries
+    ``WA_DeleteOnClose``, so closing one has Qt delete the C++ side while the
+    attribute holding it stays perfectly usable-looking. Calling into that is
+    sometimes a clean ``RuntimeError`` -- but when the deletion was partial, a
+    parent still standing with its children freed, it is an access violation
+    instead, which no ``except`` can catch. Asking first is the only guard.
+
+    Parameters
+    ----------
+    obj : QObject or None
+        The object to check.
+
+    Returns
+    -------
+    bool
+        True when `obj` exists and can still be used.
+    """
+
+    if obj is None:
+        return False
+    try:
+        import sip
+
+        return not sip.isdeleted(obj)
+    except ImportError:
+        try:
+            from PyQt5 import sip as _sip
+
+            return not _sip.isdeleted(_sip.cast(obj, type(obj)) if False else obj)
+        except Exception:
+            return True
+    except (TypeError, RuntimeError):
+        return False

--- a/celldetective/gui/base_annotator.py
+++ b/celldetective/gui/base_annotator.py
@@ -48,7 +48,7 @@ from celldetective.gui.gui_utils import (
     ExportPlotBtn,
 )
 from celldetective.gui.base.figure_canvas import FigureCanvas
-from celldetective.gui.base.utils import center_window
+from celldetective.gui.base.utils import center_window, flush_layout_events
 import gc
 from celldetective import get_logger
 
@@ -317,7 +317,7 @@ class BaseAnnotator(CelldetectiveMainWindow, Styles):
         self.del_shortcut.activated.connect(self.shortcut_suppr)
         self.del_shortcut.setEnabled(False)
 
-        QApplication.processEvents()
+        flush_layout_events(self)
 
     def generate_signal_choices(self):
         """Generate signal choice combos."""

--- a/celldetective/gui/configure_new_exp.py
+++ b/celldetective/gui/configure_new_exp.py
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtGui import QIntValidator, QDoubleValidator
 from celldetective.gui.gui_utils import help_generic
-from celldetective.gui.base.utils import center_window
+from celldetective.gui.base.utils import center_window, flush_layout_events
 from celldetective import get_software_location
 import json
 
@@ -61,7 +61,7 @@ class ConfigNewExperiment(CelldetectiveMainWindow):
         self.init_widgets()
         self.add_to_layout()
         self.connect_signals()
-        QApplication.processEvents()
+        flush_layout_events(self)
         self.adjustScrollArea()
 
     def init_widgets(self):

--- a/celldetective/gui/event_annotator.py
+++ b/celldetective/gui/event_annotator.py
@@ -45,6 +45,7 @@ from celldetective.gui.base_annotator import BaseAnnotator
 import logging
 from celldetective.log_manager import positionlogger
 from celldetective.gui.base.threads import start_tracked
+from celldetective.gui.base.utils import flush_layout_events
 
 logger = logging.getLogger("celldetective")
 
@@ -413,7 +414,7 @@ class EventAnnotator(BaseAnnotator):
         if self.class_choice_cb.currentText() != "":
             self.compute_status_and_colors(0)
 
-        QApplication.processEvents()
+        flush_layout_events(self)
 
         # Add Menu for Interactive Plotter
         menubar = self.menuBar()

--- a/celldetective/gui/gui_utils.py
+++ b/celldetective/gui/gui_utils.py
@@ -942,6 +942,7 @@ class ThresholdLineEdit(QLineEdit):
         placeholder: str = "px > thresh are masked",
         value_type: str = "float",
         *args: Any,
+        bottom: Optional[float] = None,
     ):
         """
         Initialize the ThresholdLineEdit.
@@ -960,6 +961,13 @@ class ThresholdLineEdit(QLineEdit):
             Specifies the type of threshold value, either 'float' or 'int' (default is 'float').
         *args : tuple
             Additional positional arguments passed to the parent `QLineEdit`.
+        bottom : float, optional
+            Lowest value the field will accept, for a quantity that cannot go
+            below it. Keyword-only, and `None` by default so the field takes any
+            number as before. Qt keeps a value under the bottom out of the field
+            but still lets the bottom itself and a blank field stand, so a
+            quantity that must be strictly greater has to be checked again when
+            the value is read.
         """
         super().__init__(*args)
 
@@ -969,10 +977,13 @@ class ThresholdLineEdit(QLineEdit):
         self.setPlaceholderText(placeholder)
 
         if self.value_type == "float":
-            self.setValidator(QDoubleValidator())
+            validator = QDoubleValidator()
         else:
             self.init_value = int(self.init_value)
-            self.setValidator(QIntValidator())
+            validator = QIntValidator()
+        if bottom is not None:
+            validator.setBottom(bottom)
+        self.setValidator(validator)
 
         if self.connected_buttons is not None:
             self.textChanged.connect(self.enable_btn)

--- a/celldetective/gui/pair_event_annotator.py
+++ b/celldetective/gui/pair_event_annotator.py
@@ -30,7 +30,7 @@ from celldetective.gui.base.components import (
     CelldetectiveMainWindow,
     CelldetectiveWidget,
 )
-from celldetective.gui.base.utils import center_window
+from celldetective.gui.base.utils import center_window, flush_layout_events
 from superqt import QLabeledDoubleRangeSlider, QSearchableComboBox, QLabeledSlider
 from celldetective import (
     get_software_location,
@@ -609,7 +609,7 @@ class PairEventAnnotator(CelldetectiveMainWindow):
         self.setCentralWidget(self.button_widget)
         self.show()
         self.resize(int(0.8 * self.screen_width), int(0.8 * self.screen_height))
-        QApplication.processEvents()
+        flush_layout_events(self)
 
     def fill_class_cbs(self):
         """Fill class combo boxes."""

--- a/celldetective/gui/process_block.py
+++ b/celldetective/gui/process_block.py
@@ -2181,7 +2181,23 @@ class ProcessPanel(QFrame, Styles):
         new_channels = self.segChannelWidget.channel_selection.selected_channels()
         target_cell_size = None
         if hasattr(self.segChannelWidget, "diameter_le"):
-            target_cell_size = float(self.segChannelWidget.diameter_le.get_threshold())
+            # The field's bottom turns a negative away, but a blank field and a
+            # bare zero both get past it, and both reached the configuration: a
+            # blank raised TypeError on the conversion below, a zero divided by
+            # zero once the run started. Refuse them here so nothing downstream
+            # has to read a size that cannot be one.
+            entered = self.segChannelWidget.diameter_le.get_threshold(show_warning=False)
+            if entered is None or entered <= 0:
+                msgBox = QMessageBox()
+                msgBox.setIcon(QMessageBox.Warning)
+                msgBox.setText(
+                    "Please set a cell size greater than zero, in µm."
+                )
+                msgBox.setWindowTitle("Invalid cell size")
+                msgBox.setStandardButtons(QMessageBox.Ok)
+                msgBox.exec()
+                return None
+            target_cell_size = float(entered)
 
         with open(input_config_path) as config_file:
             input_config = json.load(config_file)

--- a/celldetective/gui/process_block.py
+++ b/celldetective/gui/process_block.py
@@ -2178,10 +2178,7 @@ class ProcessPanel(QFrame, Styles):
 
         model_complete_path = locate_segmentation_model(self.model_name)
         input_config_path = model_complete_path + "config_input.json"
-        new_channels = [
-            self.segChannelWidget.channel_cbs[i].currentText()
-            for i in range(len(self.segChannelWidget.channel_cbs))
-        ]
+        new_channels = self.segChannelWidget.channel_selection.selected_channels()
         target_cell_size = None
         if hasattr(self.segChannelWidget, "diameter_le"):
             target_cell_size = float(self.segChannelWidget.diameter_le.get_threshold())
@@ -2211,10 +2208,7 @@ class ProcessPanel(QFrame, Styles):
             self.signal_models_list.currentIndex()
         ]
         _, input_config_path = _resolve_signal_model_paths(self.signal_model_name)
-        new_channels = [
-            self.signalChannelWidget.channel_cbs[i].currentText()
-            for i in range(len(self.signalChannelWidget.channel_cbs))
-        ]
+        new_channels = self.signalChannelWidget.channel_selection.selected_channels()
         with open(input_config_path) as config_file:
             input_config = json.load(config_file)
 

--- a/celldetective/gui/settings/_event_detection_model_params.py
+++ b/celldetective/gui/settings/_event_detection_model_params.py
@@ -5,18 +5,11 @@ from typing import Optional
 
 logger = logging.getLogger("celldetective")
 
-from PyQt5.QtCore import Qt
 from PyQt5.QtGui import QDoubleValidator
-from PyQt5.QtWidgets import (
-    QVBoxLayout,
-    QComboBox,
-    QHBoxLayout,
-    QLabel,
-    QPushButton,
-    QMainWindow,
-)
+from PyQt5.QtWidgets import QVBoxLayout, QPushButton, QMainWindow
 
 from celldetective.gui.base.components import CelldetectiveWidget
+from celldetective.gui.base.model_channel_selection import ModelChannelSelection
 from celldetective.gui.base.utils import center_window
 from celldetective.utils.model_loaders import locate_signal_model
 
@@ -88,34 +81,19 @@ class SignalModelParamsWidget(CelldetectiveWidget):
 
     def populate_widgets(self):
         """Populate the widgets."""
-        self.n_channels = len(self.required_channels)
-        self.channel_cbs = [QComboBox() for i in range(self.n_channels)]
-
         self.parent_window.load_available_tables()
-        available_channels = list(self.parent_window.signals) + ["None"]
-        # Populate the comboboxes with available channels from the experiment
-        for k in range(self.n_channels):
-            hbox_channel = QHBoxLayout()
-            hbox_channel.addWidget(QLabel(f"channel {k+1}: "), 33)
 
-            ch_vbox = QVBoxLayout()
-            ch_vbox.addWidget(
-                QLabel(f"Req: {self.required_channels[k]}"), alignment=Qt.AlignLeft
-            )
-            ch_vbox.addWidget(self.channel_cbs[k])
-
-            self.channel_cbs[k].addItems(
-                available_channels
-            )  # Give none option for more than one channel input
-            idx = self.channel_cbs[k].findText(self.required_channels[k])
-
-            if idx >= 0:
-                self.channel_cbs[k].setCurrentIndex(idx)
-            else:
-                self.channel_cbs[k].setCurrentIndex(len(available_channels) - 1)
-
-            hbox_channel.addLayout(ch_vbox, 66)
-            self.layout.addLayout(hbox_channel)
+        # The same rows as the segmentation channel dialog, over the measured
+        # signals rather than the experiment's channels: a signal model maps its
+        # inputs exactly the way a segmentation model does.
+        self.channel_selection = ModelChannelSelection(
+            required_channels=self.required_channels,
+            available_channels=list(self.parent_window.signals),
+            selected_channels=self.input_config.get("selected_channels"),
+        )
+        self.channel_cbs = self.channel_selection.channel_cbs
+        self.n_channels = len(self.channel_cbs)
+        self.layout.addWidget(self.channel_selection)
 
         # Button to apply the StarDist settings
         self.set_btn = QPushButton("set")

--- a/celldetective/gui/settings/_segmentation_model_params.py
+++ b/celldetective/gui/settings/_segmentation_model_params.py
@@ -147,11 +147,16 @@ class SegModelParamsWidget(CelldetectiveWidget):
             # to save, and would otherwise write the placeholder 40 µm as though it
             # had been asked for -- rescaling every later run against a number
             # nobody entered.
+            # A cell size is a physical length, so a negative one is turned away
+            # at the field. Qt still lets a bare zero and a blank field stand,
+            # and both used to be written to the model configuration; they are
+            # caught in `set_selected_channels_for_segmentation` instead.
             self.diameter_le = ThresholdLineEdit(
                 init_value=40,
                 connected_buttons=[self.view_diameter_btn],
                 placeholder="cell diameter in µm",
                 value_type="float",
+                bottom=0.0,
             )
 
             # Layout for diameter input and button

--- a/celldetective/gui/settings/_segmentation_model_params.py
+++ b/celldetective/gui/settings/_segmentation_model_params.py
@@ -6,11 +6,10 @@ from typing import Optional
 logger = logging.getLogger("celldetective")
 
 import numpy as np
-from PyQt5.QtCore import QSize, Qt
+from PyQt5.QtCore import QSize
 from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import (
     QVBoxLayout,
-    QComboBox,
     QPushButton,
     QHBoxLayout,
     QLabel,
@@ -20,6 +19,7 @@ from fonticon_mdi6 import MDI6
 from superqt.fonticon import icon
 
 from celldetective.gui.base.components import CelldetectiveWidget
+from celldetective.gui.base.model_channel_selection import ModelChannelSelection
 from celldetective.gui.base.utils import center_window
 from celldetective.gui.gui_utils import ThresholdLineEdit
 from celldetective.gui.viewers.size_viewer import CellSizeViewer
@@ -110,8 +110,17 @@ class SegModelParamsWidget(CelldetectiveWidget):
 
     def populate_widgets(self):
         """Populate the widgets."""
-        self.n_channels = len(self.required_channels)
-        self.channel_cbs = [QComboBox() for i in range(self.n_channels)]
+        # One dropdown per input slot, seeded from the mapping already stored for
+        # this model. Shared with the napari single-frame panel so that a model's
+        # inputs are mapped the same way wherever it is run from.
+        self.channel_selection = ModelChannelSelection(
+            required_channels=self.required_channels,
+            available_channels=list(self.attr_parent.exp_channels),
+            selected_channels=self.input_config.get("selected_channels"),
+        )
+        self.channel_cbs = self.channel_selection.channel_cbs
+        self.n_channels = len(self.channel_cbs)
+        self.layout.addWidget(self.channel_selection)
 
         # Button to view the current stack with a scale bar
         self.view_diameter_btn = QPushButton()
@@ -128,31 +137,6 @@ class SegModelParamsWidget(CelldetectiveWidget):
             placeholder="cell diameter in µm",
             value_type="float",
         )
-
-        available_channels = list(self.attr_parent.exp_channels) + ["None"]
-        # Populate the comboboxes with available channels from the experiment
-        for k in range(self.n_channels):
-            hbox_channel = QHBoxLayout()
-            hbox_channel.addWidget(QLabel(f"channel {k+1}: "), 33)
-
-            ch_vbox = QVBoxLayout()
-            ch_vbox.addWidget(
-                QLabel(f"Req: {self.required_channels[k]}"), alignment=Qt.AlignLeft
-            )
-            ch_vbox.addWidget(self.channel_cbs[k])
-
-            self.channel_cbs[k].addItems(
-                available_channels
-            )  # Give none option for more than one channel input
-            idx = self.channel_cbs[k].findText(self.required_channels[k])
-
-            if idx >= 0:
-                self.channel_cbs[k].setCurrentIndex(idx)
-            else:
-                self.channel_cbs[k].setCurrentIndex(len(available_channels) - 1)
-
-            hbox_channel.addLayout(ch_vbox, 66)
-            self.layout.addLayout(hbox_channel)
 
         if "cell_size_um" in self.input_config:
 

--- a/celldetective/gui/settings/_segmentation_model_params.py
+++ b/celldetective/gui/settings/_segmentation_model_params.py
@@ -23,7 +23,10 @@ from celldetective.gui.base.model_channel_selection import ModelChannelSelection
 from celldetective.gui.base.utils import center_window
 from celldetective.gui.gui_utils import ThresholdLineEdit
 from celldetective.gui.viewers.size_viewer import CellSizeViewer
-from celldetective.utils.model_loaders import locate_segmentation_model
+from celldetective.utils.model_loaders import (
+    locate_segmentation_model,
+    trained_cell_size_um,
+)
 
 
 class SegModelParamsWidget(CelldetectiveWidget):
@@ -130,15 +133,26 @@ class SegModelParamsWidget(CelldetectiveWidget):
         self.view_diameter_btn.setIconSize(QSize(20, 20))
         self.view_diameter_btn.clicked.connect(self.view_current_stack_with_scale_bar)
 
-        # Line edit for entering cell diameter
-        self.diameter_le = ThresholdLineEdit(
-            init_value=40,
-            connected_buttons=[self.view_diameter_btn],
-            placeholder="cell diameter in µm",
-            value_type="float",
-        )
+        # The size the model was trained on, which the cell size entered below is
+        # rescaled against. Shared with the library and the napari panel, so a
+        # generic Cellpose model -- which states that size in pixels rather than
+        # in microns -- gets the row here too, and is rescaled the same way
+        # wherever it is run from.
+        trained = trained_cell_size_um(self.input_config)
 
-        if "cell_size_um" in self.input_config:
+        if trained is not None:
+
+            # Only built when it is shown: `set_selected_channels_for_segmentation`
+            # tests for this attribute to decide whether the user has a cell size
+            # to save, and would otherwise write the placeholder 40 µm as though it
+            # had been asked for -- rescaling every later run against a number
+            # nobody entered.
+            self.diameter_le = ThresholdLineEdit(
+                init_value=40,
+                connected_buttons=[self.view_diameter_btn],
+                placeholder="cell diameter in µm",
+                value_type="float",
+            )
 
             # Layout for diameter input and button
             hbox = QHBoxLayout()
@@ -147,7 +161,10 @@ class SegModelParamsWidget(CelldetectiveWidget):
             hbox.addWidget(self.view_diameter_btn)
             self.layout.addLayout(hbox)
 
-            self.diameter_le.set_threshold(self.input_config["cell_size_um"])
+            # Reopen on the size last saved for this model, as the channel rows
+            # do; only falling back on the trained size the first time round.
+            stored = self.input_config.get("target_cell_size_um")
+            self.diameter_le.set_threshold(stored if stored is not None else trained)
 
             # size_hbox = QHBoxLayout()
             # size_hbox.addWidget(QLabel('cell size [µm]: '), 33)

--- a/celldetective/gui/settings/_settings_base.py
+++ b/celldetective/gui/settings/_settings_base.py
@@ -8,7 +8,7 @@ from PyQt5.QtWidgets import (
 )
 from PyQt5.QtCore import Qt
 from celldetective import get_software_location
-from celldetective.gui.base.utils import center_window
+from celldetective.gui.base.utils import center_window, flush_layout_events
 from celldetective.gui.base.components import (
     CelldetectiveMainWindow,
     CelldetectiveWidget,
@@ -84,7 +84,7 @@ class CelldetectiveSettingsPanel(CelldetectiveMainWindow):
         self._scroll_area.setWidgetResizable(True)
         self.setCentralWidget(self._scroll_area)
 
-        QApplication.processEvents()
+        flush_layout_events(self)
 
     @abstractmethod
     def _load_previous_instructions(self):

--- a/celldetective/gui/settings/_settings_neighborhood.py
+++ b/celldetective/gui/settings/_settings_neighborhood.py
@@ -15,7 +15,7 @@ from PyQt5.QtWidgets import (
 from PyQt5.QtCore import Qt, QSize
 from celldetective.gui.gui_utils import DistanceChoice
 from celldetective.gui.base.list_widget import ListWidget
-from celldetective.gui.base.utils import center_window
+from celldetective.gui.base.utils import center_window, flush_layout_events
 from superqt.fonticon import icon
 from fonticon_mdi6 import MDI6
 import numpy as np
@@ -137,7 +137,7 @@ class SettingsNeighborhood(CelldetectiveWidget):
         main_layout.addWidget(self.submit_btn)
 
         self.adjustSize()
-        QApplication.processEvents()
+        flush_layout_events(self)
 
     def populate_measurement_frame(self):
         """

--- a/celldetective/gui/thresholds_gui.py
+++ b/celldetective/gui/thresholds_gui.py
@@ -38,6 +38,7 @@ from celldetective.gui.base.components import (
 from celldetective.gui.gui_utils import color_from_class, help_generic
 from celldetective.gui.base.figure_canvas import FigureCanvas
 from celldetective.gui.base.threads import start_tracked, stop_thread
+from celldetective.gui.base.utils import is_alive
 from celldetective.gui.viewers.threshold_viewer import ThresholdedStackVisualizer
 from celldetective.utils.image_loaders import load_frames
 
@@ -897,6 +898,12 @@ class ThresholdConfigWizard(CelldetectiveMainWindow):
             self.features_cb[i].clear()
 
         self.property_query_le.setText("")
+
+        # The viewer is a separate window the user may already have closed;
+        # `WA_DeleteOnClose` means this attribute then refers to a deleted
+        # object, and driving it from a slider signal is an access violation.
+        if not is_alive(self.viewer):
+            return
 
         self.viewer.change_threshold(self.threshold_slider.value())
         self.viewer.scat_markers.set_color("tab:red")

--- a/celldetective/gui/viewers/threshold_viewer.py
+++ b/celldetective/gui/viewers/threshold_viewer.py
@@ -9,6 +9,7 @@ from superqt import QLabeledDoubleSlider
 from celldetective.gui.gui_utils import QuickSliderLayout
 from celldetective.gui.viewers.base_viewer import StackVisualizer
 from celldetective import get_logger
+from celldetective.gui.base.utils import is_alive
 
 logger = get_logger(__name__)
 
@@ -235,7 +236,11 @@ class ThresholdedStackVisualizer(StackVisualizer):
 
         # Sync slider if value came from external source (like Wizard)
         # to prevent slider from being "stale" and overwriting with old value later
-        if hasattr(self, "threshold_slider"):
+        # `is_alive`, not just `hasattr`: the attribute survives the C++ slider,
+        # and superqt's labeled slider reaches into its own internal label on
+        # setValue -- if that has been freed, the write is an access violation
+        # rather than the RuntimeError the `except` below could absorb.
+        if is_alive(getattr(self, "threshold_slider", None)):
             display_val = value
             if isinstance(value, (list, tuple, np.ndarray)):
                 display_val = value[0]

--- a/celldetective/napari/frame_segmentation.py
+++ b/celldetective/napari/frame_segmentation.py
@@ -37,6 +37,7 @@ from PyQt5.QtWidgets import (
 
 from celldetective import get_logger
 from celldetective.gui.base.model_channel_selection import ModelChannelSelection
+from celldetective.utils.model_loaders import trained_cell_size_um
 from celldetective.utils.experiment import (
     extract_experiment_channels,
     extract_experiment_from_position,
@@ -370,7 +371,6 @@ class FrameSegmentationPanel(QWidget):
             self.spatial_calibration = None
 
         self.channel_selection: Optional[ModelChannelSelection] = None
-        self.diameter_le: Optional[_FloatEdit] = None
         self.cellprob_le: Optional[_FloatEdit] = None
         self.flow_le: Optional[_FloatEdit] = None
         self.cell_size_le: Optional[_FloatEdit] = None
@@ -397,11 +397,24 @@ class FrameSegmentationPanel(QWidget):
             window = None
 
         if window is not None:
+            if self._watched_window is not None:
+                # Re-installing on a window already watched would have the filter
+                # run twice per event; take the old one off first.
+                try:
+                    self._watched_window.removeEventFilter(self)
+                except RuntimeError as e:
+                    logger.debug(f"Previously watched window already gone: {e}")
             window.installEventFilter(self)
             self._watched_window = window
 
         app = QApplication.instance()
         if app is not None:
+            # Qt.UniqueConnection would raise on the second call; the panel may be
+            # shown again after a close, so ask for the connection only once.
+            try:
+                app.aboutToQuit.disconnect(self._stop_worker)
+            except TypeError:
+                pass
             app.aboutToQuit.connect(self._stop_worker)
 
     def eventFilter(self, watched, event) -> bool:
@@ -518,7 +531,6 @@ class FrameSegmentationPanel(QWidget):
         self._clear(self.channel_layout)
         self._clear(self.param_form)
         self.channel_selection = None
-        self.diameter_le = None
         self.cellprob_le = None
         self.flow_le = None
         self.cell_size_le = None
@@ -562,18 +574,35 @@ class FrameSegmentationPanel(QWidget):
         )
         self.channel_layout.addWidget(self.channel_selection)
 
+    def _trained_cell_size_um(self) -> Optional[float]:
+        """
+        The physical object size the selected model was trained on, in microns.
+
+        Delegates to :func:`~celldetective.utils.model_loaders.trained_cell_size_um`,
+        which is also what ``prepare_segmentation_model`` and the main window's
+        channel dialog read: a model has to be rescaled the same way wherever it
+        is run from.
+
+        Returns
+        -------
+        float or None
+            The trained object size in microns, or None when the model gives no
+            way to work it out -- in which case there is nothing to rescale
+            against, and no cell size row is shown.
+        """
+
+        return trained_cell_size_um(self.config)
+
     def _build_parameter_rows(self) -> None:
         """Expose the inference parameters that this model type actually takes."""
 
         model_type = self.config.get("model_type")
 
         if model_type == "cellpose":
-            self.diameter_le = _FloatEdit(self.config.get("diameter"))
-            self.diameter_le.setToolTip(
-                "Cellpose object diameter, in pixels. Blank uses the model's own value."
-            )
-            self.param_form.addRow(QLabel("diameter [px]:"), self.diameter_le)
-
+            # No diameter row on purpose. It is the size the network was trained
+            # to see -- 30 px for a cyto model -- not a knob: the frame is
+            # rescaled so that objects arrive at that size, which is what the
+            # cell size below controls.
             self.cellprob_le = _FloatEdit(self.config.get("cellprob_threshold"))
             self.cellprob_le.setToolTip(
                 "Lower to keep more objects, raise to keep fewer."
@@ -586,14 +615,14 @@ class FrameSegmentationPanel(QWidget):
             )
             self.param_form.addRow(QLabel("flow threshold:"), self.flow_le)
 
-        if "cell_size_um" in self.config:
-            trained = self.config["cell_size_um"]
+        trained = self._trained_cell_size_um()
+        if trained is not None:
             self.cell_size_le = _FloatEdit(
                 self.config.get("target_cell_size_um", trained), bottom=0.0
             )
             self.cell_size_le.setToolTip(
                 f"Typical object size in these images, in µm.\n"
-                f"The model was trained on objects of about {trained} µm;\n"
+                f"The model was trained on objects of about {trained:.4g} µm;\n"
                 f"the frame is rescaled to match."
             )
             self.param_form.addRow(QLabel("cell size [µm]:"), self.cell_size_le)
@@ -650,7 +679,6 @@ class FrameSegmentationPanel(QWidget):
         if self.channel_selection is not None:
             self.channel_selection.setEnabled(not running)
         for edit in (
-            self.diameter_le,
             self.cellprob_le,
             self.flow_le,
             self.cell_size_le,
@@ -697,6 +725,10 @@ class FrameSegmentationPanel(QWidget):
             worker.stage.disconnect()
             worker.succeeded.disconnect()
             worker.failed.disconnect()
+            # `finished` too: `showEvent` clears `_closing`, so a panel shown
+            # again would let a detached worker's `finished` run, dropping
+            # `_worker` and flipping the UI back to idle underneath a newer run.
+            worker.finished.disconnect()
         except (TypeError, RuntimeError) as e:
             # Already disconnected, or the C++ object is gone: nothing to undo.
             logger.debug(f"Could not disconnect the segmentation worker: {e}")
@@ -730,6 +762,11 @@ class FrameSegmentationPanel(QWidget):
         # screen again is not dying, and leaving the latch set would make every
         # later run hang with its labels silently discarded.
         self._closing = False
+        # `closeEvent` took the filter off the viewer window and dropped the
+        # reference; without putting it back, a panel shown again would never
+        # learn that the viewer closed and would let a worker outlive it.
+        if self._watched_window is None:
+            self._install_close_hook()
         super().showEvent(event)
 
     def _on_run_clicked(self) -> None:
@@ -779,20 +816,20 @@ class FrameSegmentationPanel(QWidget):
             )
             return
 
-        diameter = self.diameter_le.value() if self.diameter_le else None
         cellprob = self.cellprob_le.value() if self.cellprob_le else None
         flow = self.flow_le.value() if self.flow_le else None
 
-        # Only what the model is built from. The Cellpose thresholds and diameter
-        # are passed to inference, not to the constructor, so they are re-applied
-        # to a cached model instead of forcing it to be loaded again.
+        # Only what the model is built from. The Cellpose thresholds are passed
+        # to inference, not to the constructor, so they are re-applied to a
+        # cached model instead of forcing it to be loaded again. The cell size is
+        # in here because it sets the rescaling, which is baked into the model.
         cache_key = (
             model_name,
             tuple(selected) if selected is not None else None,
             target_cell_size,
         )
 
-        cached = self._reuse_prepared(cache_key, diameter, cellprob, flow)
+        cached = self._reuse_prepared(cache_key, cellprob, flow)
 
         # The GPU is left to napari's renderer: a single frame is quick on CPU,
         # and a TensorFlow context would compete for the VRAM the viewer is
@@ -808,7 +845,6 @@ class FrameSegmentationPanel(QWidget):
             use_stored_mapping=True,
             selected_channels=selected,
             target_cell_size=target_cell_size,
-            diameter=diameter,
             cellprob_threshold=cellprob,
             flow_threshold=flow,
         )
@@ -840,15 +876,14 @@ class FrameSegmentationPanel(QWidget):
     def _reuse_prepared(
         self,
         cache_key,
-        diameter: Optional[float],
         cellprob: Optional[float],
         flow: Optional[float],
     ):
         """
         Fetch a prepared model for these settings and re-apply the inference values.
 
-        The Cellpose diameter and thresholds are arguments to the forward pass, not
-        to the constructor, so a change to any of them only has to be written onto
+        The Cellpose thresholds are arguments to the forward pass, not to the
+        constructor, so a change to either of them only has to be written onto
         the model rather than causing a new one to be loaded. A field left blank
         means "use the model's own value", which is what
         ``PreparedSegmentationModel.config_defaults`` holds.
@@ -857,7 +892,7 @@ class FrameSegmentationPanel(QWidget):
         ----------
         cache_key : tuple
             Identity of the model to look up.
-        diameter, cellprob, flow : float or None
+        cellprob, flow : float or None
             The values entered in the panel, None meaning the model's own.
 
         Returns
@@ -875,9 +910,9 @@ class FrameSegmentationPanel(QWidget):
 
         if prepared.model_type == "cellpose":
             defaults = prepared.config_defaults
-            prepared.diameter = (
-                diameter if diameter is not None else defaults.get("diameter")
-            )
+            # Never overridden from the panel: the diameter is the size the
+            # network was trained to see, and the frame is rescaled to it.
+            prepared.diameter = defaults.get("diameter")
             prepared.cellprob_threshold = (
                 cellprob
                 if cellprob is not None
@@ -901,8 +936,49 @@ class FrameSegmentationPanel(QWidget):
         self.status_lbl.setText(message)
         self.viewer.status = message
 
+    def _rebuild_rows_if_downloaded(
+        self, model_name: str, cache_key: Optional[tuple] = None
+    ) -> None:
+        """
+        Build the channel and parameter rows for a model fetched during this run.
+
+        A repository model has no configuration on disk until its first run
+        downloads it, so the panel is still showing the "not downloaded yet"
+        placeholder with no rows. Build them now, rather than leaving the user to
+        cycle the dropdown to get at a mapping the model has had all along --
+        which a combo box will not even do for the entry already selected.
+
+        Parameters
+        ----------
+        model_name : str
+            The model the finished run used.
+        cache_key : tuple, optional
+            The key the run's prepared model was stored under, when it succeeded.
+        """
+
+        if (
+            self.config is not None
+            or not model_name
+            or model_name != self.model_cb.currentText()
+        ):
+            return
+
+        self._reload_model(model_name)
+        if self.config is not None and cache_key is not None:
+            # Those rows feed the cache key, so the entry just stored is keyed on
+            # a state that can never come back; drop it rather than hold a few
+            # hundred MB of network alive for a key nothing will ask for.
+            self._prepared.pop(cache_key, None)
+
     def _on_failed(self, message: str) -> None:
         """Report a worker failure."""
+        # The download half of a run can succeed while inference fails -- a model
+        # whose declared channel names match nothing in the experiment fails
+        # exactly that way. Its configuration is on disk now, so pick the rows up
+        # before reporting, or the panel dead-ends: every retry resolves the same
+        # unmappable channels and fails identically.
+        pending = self._pending or {}
+        self._rebuild_rows_if_downloaded(pending.get("model_name", ""))
         self._failed(message)
 
     def _on_worker_finished(self) -> None:
@@ -1005,22 +1081,7 @@ class FrameSegmentationPanel(QWidget):
         if cache_key is not None:
             self._cache_prepared(cache_key, prepared)
 
-        # A model fetched during this very run: its configuration only reached the
-        # disk once the worker had started, so the panel is still showing the
-        # "not downloaded yet" placeholder with no channel or parameter rows.
-        # Build them now, rather than leaving the user to cycle the dropdown to
-        # get at a mapping the model has had all along.
-        if (
-            self.config is None
-            and model_name
-            and model_name == self.model_cb.currentText()
-        ):
-            self._reload_model(model_name)
-            if self.config is not None and cache_key is not None:
-                # Those rows feed the cache key, so the entry just stored is keyed
-                # on a state that can never come back; drop it rather than hold a
-                # few hundred MB of network alive for a key nothing will ask for.
-                self._prepared.pop(cache_key, None)
+        self._rebuild_rows_if_downloaded(model_name, cache_key)
 
         # The viewer may have been closed while the worker was running.
         try:

--- a/celldetective/napari/frame_segmentation.py
+++ b/celldetective/napari/frame_segmentation.py
@@ -1,0 +1,488 @@
+"""
+Segment the frame on screen, from inside the napari correction viewer.
+
+The panel mirrors the channel-selection dialog of the main window: one dropdown
+per input slot of the chosen model, plus whatever inference parameters that
+model type actually takes. Values are seeded from the model's
+``config_input.json`` -- including any ``selected_channels`` mapping already set
+in the main window -- but edits stay local to the napari session and are never
+written back, so trying settings out here cannot silently change the next
+full-stack run.
+"""
+
+import json
+import os
+from typing import Any, Dict, List, Optional
+
+import numpy as np
+from PyQt5.QtCore import Qt
+from PyQt5.QtGui import QDoubleValidator
+from PyQt5.QtWidgets import (
+    QApplication,
+    QCheckBox,
+    QComboBox,
+    QFormLayout,
+    QGroupBox,
+    QHBoxLayout,
+    QLabel,
+    QLineEdit,
+    QMessageBox,
+    QPushButton,
+    QVBoxLayout,
+    QWidget,
+)
+
+from celldetective import get_logger
+from celldetective.utils.experiment import (
+    extract_experiment_channels,
+    extract_experiment_from_position,
+    get_spatial_calibration,
+)
+from celldetective.utils.model_loaders import locate_segmentation_model
+
+logger = get_logger()
+
+# Offered in the model dropdown when nothing is installed, so that the panel --
+# and with it the whole viewer -- still builds.
+NO_MODEL = "(no segmentation model found)"
+
+# The channel-selection dialog uses this spelling for an unused input slot, and
+# it is what ends up in `selected_channels`, so match it exactly.
+NO_CHANNEL = "None"
+
+
+def _read_model_config(model_name: str) -> Optional[Dict[str, Any]]:
+    """
+    Read a segmentation model's input configuration, without downloading it.
+
+    Parameters
+    ----------
+    model_name : str
+        Name of the segmentation model.
+
+    Returns
+    -------
+    dict or None
+        The parsed ``config_input.json``, or None when the model is not present
+        locally (it lives in the remote repository and has not been fetched yet)
+        or its configuration cannot be read.
+    """
+
+    try:
+        model_path = locate_segmentation_model(model_name, download=False)
+    except Exception as e:
+        logger.debug(f"Could not locate model '{model_name}': {e}")
+        return None
+    if model_path is None:
+        return None
+
+    config_path = os.path.join(model_path, "config_input.json")
+    if not os.path.exists(config_path):
+        return None
+    try:
+        with open(config_path) as config_file:
+            return json.load(config_file)
+    except Exception as e:
+        logger.warning(f"Could not read the configuration of '{model_name}': {e}")
+        return None
+
+
+def available_segmentation_models(population: str) -> List[str]:
+    """
+    List the models offered in the panel: population-specific first, then generic.
+
+    Parameters
+    ----------
+    population : str
+        The population whose model family to list, e.g. ``"targets"``.
+
+    Returns
+    -------
+    list of str
+        Model names without duplicates. Never empty: a placeholder is returned
+        when nothing can be listed, so the dropdown always builds.
+    """
+
+    from celldetective.utils.model_getters import get_segmentation_models_list
+
+    models: List[str] = []
+    for mode in (population, "generic"):
+        try:
+            models.extend(get_segmentation_models_list(mode=mode, return_path=False))
+        except Exception as e:
+            # Listing reaches out to the model repository; being offline must not
+            # stop the viewer from opening.
+            logger.warning(f"Could not list the '{mode}' segmentation models: {e}")
+
+    seen = set()
+    models = [m for m in models if not (m in seen or seen.add(m))]
+    return models or [NO_MODEL]
+
+
+class _FloatEdit(QLineEdit):
+    """A line edit accepting a single float, blank meaning "use the model's value"."""
+
+    def __init__(self, value: Optional[float] = None, parent=None):
+        super().__init__(parent)
+        self.setValidator(QDoubleValidator())
+        if value is not None:
+            self.setText(str(value))
+
+    def value(self) -> Optional[float]:
+        """Return the entered number, or None when the field is blank or invalid."""
+        text = self.text().strip().replace(",", ".")
+        if not text:
+            return None
+        try:
+            return float(text)
+        except ValueError:
+            return None
+
+
+class FrameSegmentationPanel(QWidget):
+    """
+    Dock panel that runs a segmentation model on the frame currently displayed.
+
+    Parameters
+    ----------
+    viewer : napari.Viewer
+        The viewer holding the ``segmentation`` labels layer to write into.
+    stack : ndarray
+        The image stack being displayed (TYXC), used as the pixel source so the
+        panel does not depend on how the image layers happen to be named.
+    position : str
+        The position directory, used to locate the experiment configuration.
+    population : str
+        The population being segmented, selecting the model family to offer.
+    """
+
+    def __init__(self, viewer, stack, position: str, population: str, parent=None):
+        super().__init__(parent)
+
+        self.viewer = viewer
+        self.stack = stack
+        self.position = position
+        self.population = population
+
+        # One entry per (model, channel mapping, parameters) actually used, so
+        # that repeated runs with the same settings only pay for inference.
+        self._prepared: Dict[Any, Any] = {}
+
+        self.experiment = extract_experiment_from_position(position)
+        try:
+            self.exp_channels = list(extract_experiment_channels(self.experiment)[0])
+        except Exception as e:
+            logger.warning(f"Could not read the experiment channels: {e}")
+            self.exp_channels = []
+        try:
+            self.spatial_calibration = get_spatial_calibration(self.experiment)
+        except Exception as e:
+            logger.warning(f"Could not read the spatial calibration: {e}")
+            self.spatial_calibration = None
+
+        self.channel_cbs: List[QComboBox] = []
+        self.diameter_le: Optional[_FloatEdit] = None
+        self.cellprob_le: Optional[_FloatEdit] = None
+        self.flow_le: Optional[_FloatEdit] = None
+        self.cell_size_le: Optional[_FloatEdit] = None
+        self.config: Optional[Dict[str, Any]] = None
+
+        self._build()
+
+    # ------------------------------------------------------------------
+    # Construction
+    # ------------------------------------------------------------------
+
+    def _build(self) -> None:
+        """Lay out the panel and fill it for the initially selected model."""
+
+        outer = QVBoxLayout(self)
+        outer.setContentsMargins(6, 6, 6, 6)
+        outer.setSpacing(8)
+
+        model_row = QHBoxLayout()
+        model_row.addWidget(QLabel("model:"), 30)
+        self.model_cb = QComboBox()
+        self.model_cb.addItems(available_segmentation_models(self.population))
+        self.model_cb.setToolTip(
+            "Segmentation model to run on the frame currently displayed."
+        )
+        model_row.addWidget(self.model_cb, 70)
+        outer.addLayout(model_row)
+
+        self.channel_box = QGroupBox("channels")
+        self.channel_form = QFormLayout(self.channel_box)
+        self.channel_form.setContentsMargins(8, 8, 8, 8)
+        outer.addWidget(self.channel_box)
+
+        self.param_box = QGroupBox("parameters")
+        self.param_form = QFormLayout(self.param_box)
+        self.param_form.setContentsMargins(8, 8, 8, 8)
+        outer.addWidget(self.param_box)
+
+        self.replace_cb = QCheckBox("Replace the labels on this frame")
+        self.replace_cb.setChecked(True)
+        self.replace_cb.setToolTip(
+            "Unticked, existing labels are kept and the new ones only fill the\n"
+            "background, so manual corrections on this frame survive."
+        )
+        outer.addWidget(self.replace_cb)
+
+        self.run_btn = QPushButton("Segment this frame")
+        self.run_btn.clicked.connect(self.segment_current_frame)
+        outer.addWidget(self.run_btn)
+
+        self.model_cb.currentTextChanged.connect(self._reload_model)
+        self._reload_model(self.model_cb.currentText())
+
+    def _clear(self, form: QFormLayout) -> None:
+        """Remove every row from a form layout."""
+        while form.count():
+            item = form.takeAt(0)
+            widget = item.widget()
+            if widget is not None:
+                widget.deleteLater()
+
+    def _reload_model(self, model_name: str) -> None:
+        """
+        Rebuild the channel and parameter rows for the selected model.
+
+        Parameters
+        ----------
+        model_name : str
+            The newly selected model.
+        """
+
+        self._clear(self.channel_form)
+        self._clear(self.param_form)
+        self.channel_cbs = []
+        self.diameter_le = None
+        self.cellprob_le = None
+        self.flow_le = None
+        self.cell_size_le = None
+
+        if not model_name or model_name == NO_MODEL:
+            self.config = None
+            self.channel_form.addRow(QLabel("No model available."))
+            self.run_btn.setEnabled(False)
+            return
+
+        self.run_btn.setEnabled(True)
+        self.config = _read_model_config(model_name)
+
+        if self.config is None:
+            # A repository model that has not been fetched yet: its channels and
+            # parameters are unknown until it lands on disk.
+            self.channel_form.addRow(
+                QLabel("Not downloaded yet.\nIt will be fetched on the first run,\nusing the model's own settings.")
+            )
+            return
+
+        self._build_channel_rows()
+        self._build_parameter_rows()
+
+    def _build_channel_rows(self) -> None:
+        """One dropdown per model input slot, seeded from the stored mapping."""
+
+        required = list(self.config.get("channels", []))
+        stored = self.config.get("selected_channels")
+        options = list(self.exp_channels) + [NO_CHANNEL]
+
+        for i, slot in enumerate(required):
+            combo = QComboBox()
+            combo.addItems(options)
+            combo.setToolTip(f"Experiment channel feeding the model's '{slot}' input.")
+
+            # Prefer the mapping the main window already saved, then a plain name
+            # match, and leave the slot empty when neither is available.
+            default = None
+            if isinstance(stored, list) and i < len(stored):
+                default = stored[i]
+            if default is None or combo.findText(str(default)) < 0:
+                default = slot if slot in self.exp_channels else NO_CHANNEL
+
+            idx = combo.findText(str(default))
+            combo.setCurrentIndex(idx if idx >= 0 else len(options) - 1)
+
+            self.channel_cbs.append(combo)
+            self.channel_form.addRow(QLabel(f"{slot}:"), combo)
+
+        if not required:
+            self.channel_form.addRow(QLabel("This model declares no input channels."))
+
+    def _build_parameter_rows(self) -> None:
+        """Expose the inference parameters that this model type actually takes."""
+
+        model_type = self.config.get("model_type")
+
+        if model_type == "cellpose":
+            self.diameter_le = _FloatEdit(self.config.get("diameter"))
+            self.diameter_le.setToolTip(
+                "Cellpose object diameter, in pixels. Blank uses the model's own value."
+            )
+            self.param_form.addRow(QLabel("diameter [px]:"), self.diameter_le)
+
+            self.cellprob_le = _FloatEdit(self.config.get("cellprob_threshold"))
+            self.cellprob_le.setToolTip(
+                "Lower to keep more objects, raise to keep fewer."
+            )
+            self.param_form.addRow(QLabel("cell probability:"), self.cellprob_le)
+
+            self.flow_le = _FloatEdit(self.config.get("flow_threshold"))
+            self.flow_le.setToolTip(
+                "Maximum flow error allowed per mask. Raise to keep more objects."
+            )
+            self.param_form.addRow(QLabel("flow threshold:"), self.flow_le)
+
+        if "cell_size_um" in self.config:
+            trained = self.config["cell_size_um"]
+            self.cell_size_le = _FloatEdit(
+                self.config.get("target_cell_size_um", trained)
+            )
+            self.cell_size_le.setToolTip(
+                f"Typical object size in these images, in µm.\n"
+                f"The model was trained on objects of about {trained} µm;\n"
+                f"the frame is rescaled to match."
+            )
+            self.param_form.addRow(QLabel("cell size [µm]:"), self.cell_size_le)
+
+        if self.param_form.count() == 0:
+            self.param_form.addRow(
+                QLabel(f"No adjustable parameters for a {model_type} model.")
+            )
+
+    # ------------------------------------------------------------------
+    # Running
+    # ------------------------------------------------------------------
+
+    def _selected_channels(self) -> Optional[List[str]]:
+        """The channel mapping as currently set, or None when the model is unknown."""
+        if not self.channel_cbs:
+            return None
+        return [combo.currentText() for combo in self.channel_cbs]
+
+    def _failed(self, message: str) -> None:
+        """
+        Report a failure without tearing down the viewer.
+
+        Parameters
+        ----------
+        message : str
+            Shown to the user and written to the log.
+        """
+
+        logger.error(message)
+        self.viewer.status = message
+        try:
+            box = QMessageBox(self)
+            box.setIcon(QMessageBox.Warning)
+            box.setText(message)
+            box.setWindowTitle("Segmentation")
+            box.setStandardButtons(QMessageBox.Ok)
+            box.exec_()
+        except Exception as e:
+            logger.debug(f"Could not show the segmentation error dialog: {e}")
+
+    def segment_current_frame(self) -> None:
+        """
+        Run the selected model on the frame the time slider is on.
+
+        The result is written straight into the segmentation layer; nothing
+        reaches disk until the labels are saved.
+        """
+
+        model_name = self.model_cb.currentText()
+        if not model_name or model_name == NO_MODEL:
+            self._failed(
+                "No segmentation model is available. Download or train one first."
+            )
+            return
+
+        selected = self._selected_channels()
+        if selected is not None and all(ch == NO_CHANNEL for ch in selected):
+            self._failed(
+                "Every input channel is set to None. Assign at least one experiment "
+                "channel to a model input."
+            )
+            return
+
+        t = int(self.viewer.dims.current_step[0])
+
+        target_cell_size = self.cell_size_le.value() if self.cell_size_le else None
+        diameter = self.diameter_le.value() if self.diameter_le else None
+        cellprob = self.cellprob_le.value() if self.cellprob_le else None
+        flow = self.flow_le.value() if self.flow_le else None
+
+        # Settings are part of the identity of a prepared model: changing the
+        # mapping or a threshold has to rebuild it, not reuse the last one.
+        cache_key = (
+            model_name,
+            tuple(selected) if selected is not None else None,
+            target_cell_size,
+            diameter,
+            cellprob,
+            flow,
+        )
+
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        self.viewer.status = f"Segmenting frame {t} with '{model_name}'…"
+        try:
+            prepared = self._prepared.get(cache_key)
+            if prepared is None:
+                from celldetective.segmentation import prepare_segmentation_model
+
+                # The GPU is left to napari's renderer: a single frame is quick on
+                # CPU, and a TensorFlow context would compete for the VRAM the
+                # viewer is already using.
+                prepared = prepare_segmentation_model(
+                    model_name,
+                    channels=self.exp_channels or None,
+                    spatial_calibration=self.spatial_calibration,
+                    use_gpu=False,
+                    selected_channels=selected,
+                    target_cell_size=target_cell_size,
+                    diameter=diameter,
+                    cellprob_threshold=cellprob,
+                    flow_threshold=flow,
+                )
+                if prepared is None:
+                    self._failed(
+                        f"Model '{model_name}' could not be loaded. See the log for details."
+                    )
+                    return
+                self._prepared[cache_key] = prepared
+
+            from celldetective.segmentation import segment_frame
+
+            new_labels = segment_frame(np.asarray(self.stack[t]), prepared)
+        except ValueError as e:
+            # Raised when none of the mapped channels reach the model.
+            self._failed(str(e))
+            return
+        except Exception as e:
+            logger.exception("Single-frame segmentation failed.")
+            self._failed(f"Segmentation failed: {e}")
+            return
+        finally:
+            QApplication.restoreOverrideCursor()
+
+        layer = self.viewer.layers["segmentation"]
+        try:
+            current = layer.data[t]
+            if self.replace_cb.isChecked():
+                current[...] = new_labels
+            else:
+                # Offset the incoming labels past the ones already drawn so the
+                # two sets cannot collide, then keep whatever was already there.
+                offset = int(current.max())
+                incoming = np.where(new_labels > 0, new_labels + offset, 0)
+                current[...] = np.where(current > 0, current, incoming)
+        except Exception as e:
+            self._failed(f"Could not write the labels into the viewer: {e}")
+            return
+        layer.refresh()
+
+        n_objects = int(np.max(layer.data[t]))
+        message = f"Frame {t}: {n_objects} objects after segmenting with '{model_name}'."
+        self.viewer.status = message
+        logger.info(message)

--- a/celldetective/napari/frame_segmentation.py
+++ b/celldetective/napari/frame_segmentation.py
@@ -15,10 +15,9 @@ import os
 from typing import Any, Dict, List, Optional
 
 import numpy as np
-from PyQt5.QtCore import Qt
+from PyQt5.QtCore import Qt, QThread, pyqtSignal
 from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import (
-    QApplication,
     QCheckBox,
     QComboBox,
     QFormLayout,
@@ -27,6 +26,7 @@ from PyQt5.QtWidgets import (
     QLabel,
     QLineEdit,
     QMessageBox,
+    QProgressBar,
     QPushButton,
     QVBoxLayout,
     QWidget,
@@ -139,6 +139,93 @@ class _FloatEdit(QLineEdit):
             return None
 
 
+class _SegmentationWorker(QThread):
+    """
+    Load the model and segment one frame, off the GUI thread.
+
+    Cancellation is cooperative and checked between phases: neither StarDist nor
+    Cellpose exposes a hook to interrupt a forward pass, so a cancel raised once
+    inference has started does not stop it -- it lets the interface go back to
+    normal and discards the result when it lands. Cancelling while the model is
+    still loading, which is the slow part the first time round, does take effect
+    before any inference happens.
+
+    Parameters
+    ----------
+    frame : ndarray
+        The single multichannel image to segment.
+    prepared : PreparedSegmentationModel or None
+        An already-prepared model to reuse; when None it is built from
+        ``prepare_kwargs``.
+    prepare_kwargs : dict
+        Arguments for :func:`prepare_segmentation_model`, used when `prepared`
+        is None.
+    """
+
+    #: Emitted with ``(prepared_model, labels)`` when the frame was segmented.
+    succeeded = pyqtSignal(object, object)
+    #: Emitted with a message the user should see.
+    failed = pyqtSignal(str)
+    #: Emitted with the name of the phase being entered.
+    stage = pyqtSignal(str)
+
+    def __init__(self, frame, prepared, prepare_kwargs: Dict[str, Any], parent=None):
+        super().__init__(parent)
+        self._frame = frame
+        self._prepared = prepared
+        self._prepare_kwargs = prepare_kwargs
+        self._cancelled = False
+
+    def cancel(self) -> None:
+        """Ask the worker to stop at the next phase boundary."""
+        self._cancelled = True
+
+    @property
+    def cancelled(self) -> bool:
+        """Whether cancellation was requested."""
+        return self._cancelled
+
+    def run(self) -> None:
+        """Prepare the model if needed, then segment the frame."""
+
+        from celldetective.segmentation import (
+            prepare_segmentation_model,
+            segment_frame,
+        )
+
+        try:
+            prepared = self._prepared
+            if prepared is None:
+                self.stage.emit("Loading the model…")
+                if self._cancelled:
+                    return
+                prepared = prepare_segmentation_model(**self._prepare_kwargs)
+                if prepared is None:
+                    model_name = self._prepare_kwargs.get("model_name", "the model")
+                    self.failed.emit(
+                        f"Model '{model_name}' could not be loaded. See the log for details."
+                    )
+                    return
+
+            if self._cancelled:
+                return
+
+            self.stage.emit("Segmenting the frame…")
+            labels = segment_frame(self._frame, prepared)
+        except ValueError as e:
+            # Raised when none of the mapped channels reach the model.
+            self.failed.emit(str(e))
+            return
+        except Exception as e:
+            logger.exception("Single-frame segmentation failed.")
+            self.failed.emit(f"Segmentation failed: {e}")
+            return
+
+        if self._cancelled:
+            return
+        self.succeeded.emit(prepared, labels)
+
+
 class FrameSegmentationPanel(QWidget):
     """
     Dock panel that runs a segmentation model on the frame currently displayed.
@@ -167,6 +254,11 @@ class FrameSegmentationPanel(QWidget):
         # One entry per (model, channel mapping, parameters) actually used, so
         # that repeated runs with the same settings only pay for inference.
         self._prepared: Dict[Any, Any] = {}
+
+        # The run in flight, and what it was asked to do. Kept on the panel so
+        # the thread is not garbage collected while it works.
+        self._worker: Optional[_SegmentationWorker] = None
+        self._pending: Optional[Dict[str, Any]] = None
 
         self.experiment = extract_experiment_from_position(position)
         try:
@@ -229,8 +321,22 @@ class FrameSegmentationPanel(QWidget):
         outer.addWidget(self.replace_cb)
 
         self.run_btn = QPushButton("Segment this frame")
-        self.run_btn.clicked.connect(self.segment_current_frame)
+        self.run_btn.clicked.connect(self._on_run_clicked)
         outer.addWidget(self.run_btn)
+
+        # Indeterminate: there is no progress to report from inside a forward
+        # pass, so the bar says "working" rather than how far along it is.
+        self.progress = QProgressBar()
+        self.progress.setRange(0, 0)
+        self.progress.setTextVisible(False)
+        self.progress.setFixedHeight(6)
+        self.progress.hide()
+        outer.addWidget(self.progress)
+
+        self.status_lbl = QLabel("")
+        self.status_lbl.setAlignment(Qt.AlignCenter)
+        self.status_lbl.hide()
+        outer.addWidget(self.status_lbl)
 
         self.model_cb.currentTextChanged.connect(self._reload_model)
         self._reload_model(self.model_cb.currentText())
@@ -383,13 +489,76 @@ class FrameSegmentationPanel(QWidget):
         except Exception as e:
             logger.debug(f"Could not show the segmentation error dialog: {e}")
 
+    def _set_running(self, running: bool) -> None:
+        """
+        Put the panel into its working or idle state.
+
+        Parameters
+        ----------
+        running : bool
+            True while a segmentation is in flight.
+        """
+
+        self.model_cb.setEnabled(not running)
+        self.replace_cb.setEnabled(not running)
+        for combo in self.channel_cbs:
+            combo.setEnabled(not running)
+        for edit in (
+            self.diameter_le,
+            self.cellprob_le,
+            self.flow_le,
+            self.cell_size_le,
+        ):
+            if edit is not None:
+                edit.setEnabled(not running)
+
+        self.progress.setVisible(running)
+        self.status_lbl.setVisible(running)
+        if running:
+            self.run_btn.setText("Cancel")
+            self.run_btn.setToolTip(
+                "Stop the run. Inference cannot be interrupted once it has\n"
+                "started, so the result is discarded when it lands."
+            )
+        else:
+            self.run_btn.setText("Segment this frame")
+            self.run_btn.setToolTip("")
+            # Stay disabled when there is nothing to run.
+            model_name = self.model_cb.currentText()
+            self.run_btn.setEnabled(bool(model_name) and model_name != NO_MODEL)
+            self.status_lbl.setText("")
+
+    def closeEvent(self, event) -> None:
+        """Stop a run in flight before the panel goes away."""
+        worker = self._worker
+        if worker is not None and worker.isRunning():
+            worker.cancel()
+            # Inference cannot be interrupted, so give it a moment to reach the
+            # next phase boundary rather than tearing the thread down under it.
+            worker.wait(5000)
+        super().closeEvent(event)
+
+    def _on_run_clicked(self) -> None:
+        """Start a segmentation, or cancel the one in flight."""
+        if self._worker is not None and self._worker.isRunning():
+            self._worker.cancel()
+            self.run_btn.setEnabled(False)
+            self.status_lbl.setText("Cancelling…")
+            self.viewer.status = "Cancelling the segmentation…"
+            return
+        self.segment_current_frame()
+
     def segment_current_frame(self) -> None:
         """
         Run the selected model on the frame the time slider is on.
 
-        The result is written straight into the segmentation layer; nothing
+        The work happens on a worker thread, so the viewer stays usable while it
+        runs. The result is written straight into the segmentation layer; nothing
         reaches disk until the labels are saved.
         """
+
+        if self._worker is not None and self._worker.isRunning():
+            return
 
         model_name = self.model_cb.currentText()
         if not model_name or model_name == NO_MODEL:
@@ -424,49 +593,84 @@ class FrameSegmentationPanel(QWidget):
             flow,
         )
 
-        QApplication.setOverrideCursor(Qt.WaitCursor)
+        # The GPU is left to napari's renderer: a single frame is quick on CPU,
+        # and a TensorFlow context would compete for the VRAM the viewer is
+        # already using.
+        prepare_kwargs = dict(
+            model_name=model_name,
+            channels=self.exp_channels or None,
+            spatial_calibration=self.spatial_calibration,
+            use_gpu=False,
+            selected_channels=selected,
+            target_cell_size=target_cell_size,
+            diameter=diameter,
+            cellprob_threshold=cellprob,
+            flow_threshold=flow,
+        )
+
+        self._pending = {"frame": t, "cache_key": cache_key, "model_name": model_name}
+
+        worker = _SegmentationWorker(
+            frame=np.asarray(self.stack[t]),
+            prepared=self._prepared.get(cache_key),
+            prepare_kwargs=prepare_kwargs,
+            parent=self,
+        )
+        worker.stage.connect(self._on_stage)
+        worker.succeeded.connect(self._on_succeeded)
+        worker.failed.connect(self._on_failed)
+        worker.finished.connect(self._on_worker_finished)
+        self._worker = worker
+
+        self._set_running(True)
+        self.status_lbl.setText("Starting…")
         self.viewer.status = f"Segmenting frame {t} with '{model_name}'…"
+        worker.start()
+
+    def _on_stage(self, message: str) -> None:
+        """Show the phase the worker has entered."""
+        self.status_lbl.setText(message)
+        self.viewer.status = message
+
+    def _on_failed(self, message: str) -> None:
+        """Report a worker failure."""
+        self._failed(message)
+
+    def _on_worker_finished(self) -> None:
+        """Return the panel to its idle state once the thread has ended."""
+        cancelled = self._worker is not None and self._worker.cancelled
+        self._worker = None
+        self._set_running(False)
+        if cancelled:
+            self.viewer.status = "Segmentation cancelled."
+            logger.info("Single-frame segmentation cancelled.")
+
+    def _on_succeeded(self, prepared, new_labels) -> None:
+        """
+        Write the labels the worker produced into the segmentation layer.
+
+        Parameters
+        ----------
+        prepared : PreparedSegmentationModel
+            The model used, cached so the next run with the same settings reuses it.
+        new_labels : ndarray
+            The labels for the frame that was segmented.
+        """
+
+        pending = self._pending or {}
+        t = pending.get("frame", 0)
+        model_name = pending.get("model_name", "")
+        cache_key = pending.get("cache_key")
+        if cache_key is not None:
+            self._prepared[cache_key] = prepared
+
+        # The viewer may have been closed while the worker was running.
         try:
-            prepared = self._prepared.get(cache_key)
-            if prepared is None:
-                from celldetective.segmentation import prepare_segmentation_model
-
-                # The GPU is left to napari's renderer: a single frame is quick on
-                # CPU, and a TensorFlow context would compete for the VRAM the
-                # viewer is already using.
-                prepared = prepare_segmentation_model(
-                    model_name,
-                    channels=self.exp_channels or None,
-                    spatial_calibration=self.spatial_calibration,
-                    use_gpu=False,
-                    selected_channels=selected,
-                    target_cell_size=target_cell_size,
-                    diameter=diameter,
-                    cellprob_threshold=cellprob,
-                    flow_threshold=flow,
-                )
-                if prepared is None:
-                    self._failed(
-                        f"Model '{model_name}' could not be loaded. See the log for details."
-                    )
-                    return
-                self._prepared[cache_key] = prepared
-
-            from celldetective.segmentation import segment_frame
-
-            new_labels = segment_frame(np.asarray(self.stack[t]), prepared)
-        except ValueError as e:
-            # Raised when none of the mapped channels reach the model.
-            self._failed(str(e))
-            return
+            layer = self.viewer.layers["segmentation"]
         except Exception as e:
-            logger.exception("Single-frame segmentation failed.")
-            self._failed(f"Segmentation failed: {e}")
+            logger.debug(f"Segmentation layer is gone, dropping the result: {e}")
             return
-        finally:
-            QApplication.restoreOverrideCursor()
 
-        layer = self.viewer.layers["segmentation"]
         try:
             current = layer.data[t]
             if self.replace_cb.isChecked():

--- a/celldetective/napari/frame_segmentation.py
+++ b/celldetective/napari/frame_segmentation.py
@@ -12,12 +12,14 @@ full-stack run.
 
 import json
 import os
-from typing import Any, Dict, List, Optional
+from collections import OrderedDict
+from typing import Any, Dict, List, Optional, Set
 
 import numpy as np
-from PyQt5.QtCore import Qt, QThread, pyqtSignal
+from PyQt5.QtCore import QEvent, Qt, QThread, pyqtSignal
 from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import (
+    QApplication,
     QCheckBox,
     QComboBox,
     QFormLayout,
@@ -40,7 +42,7 @@ from celldetective.utils.experiment import (
 )
 from celldetective.utils.model_loaders import locate_segmentation_model
 
-logger = get_logger()
+logger = get_logger(__name__)
 
 # Offered in the model dropdown when nothing is installed, so that the panel --
 # and with it the whole viewer -- still builds.
@@ -49,6 +51,17 @@ NO_MODEL = "(no segmentation model found)"
 # The channel-selection dialog uses this spelling for an unused input slot, and
 # it is what ends up in `selected_channels`, so match it exactly.
 NO_CHANNEL = "None"
+
+# How many prepared models the panel keeps alive at once. Each one is a whole
+# StarDist / Cellpose network, so the cache trades a few hundred MB for not
+# reloading when the user goes back and forth between two settings.
+MAX_CACHED_MODELS = 2
+
+# Workers that have been started and not yet finished. A QThread must outlive its
+# own `run()`, and destroying one that is still running is a fatal error in Qt, so
+# the thread objects are parented to nothing and held here instead of on the panel
+# -- that way closing the viewer cannot take a running thread down with it.
+_LIVE_WORKERS: Set["_SegmentationWorker"] = set()
 
 
 def _read_model_config(model_name: str) -> Optional[Dict[str, Any]]:
@@ -105,18 +118,71 @@ def available_segmentation_models(population: str) -> List[str]:
 
     from celldetective.utils.model_getters import get_segmentation_models_list
 
+    # "target" / "effector" are used interchangeably with their plurals across the
+    # viewer, but the model directories are only ever named in the plural.
+    mode = population if population.endswith("s") else f"{population}s"
+
     models: List[str] = []
-    for mode in (population, "generic"):
+    for family in (mode, "generic"):
         try:
-            models.extend(get_segmentation_models_list(mode=mode, return_path=False))
+            # cleanup=False: listing must not create the category directory nor
+            # delete local model folders that happen to lack a config_input.json.
+            # Opening a viewer is not the moment to be rewriting the model tree.
+            models.extend(
+                get_segmentation_models_list(
+                    mode=family, return_path=False, cleanup=False
+                )
+            )
         except Exception as e:
             # Listing reaches out to the model repository; being offline must not
             # stop the viewer from opening.
-            logger.warning(f"Could not list the '{mode}' segmentation models: {e}")
+            logger.warning(f"Could not list the '{family}' segmentation models: {e}")
 
     seen = set()
     models = [m for m in models if not (m in seen or seen.add(m))]
     return models or [NO_MODEL]
+
+
+def _fit_to_layer_dtype(
+    labels: np.ndarray, dtype: np.dtype, remedy: str = ""
+) -> np.ndarray:
+    """
+    Cast labels to the segmentation layer's type, refusing to wrap round.
+
+    napari keeps the labels in whatever integer type they were read as, often
+    ``uint16``. A plain assignment of a larger value wraps silently, which merges
+    unrelated cells under one identifier - the sort of corruption that is only
+    noticed once it is in the measurements.
+
+    Parameters
+    ----------
+    labels : ndarray
+        The labels to write.
+    dtype : numpy.dtype
+        The layer's integer type.
+    remedy : str, optional
+        Appended to the error message to say what the user can do about it.
+
+    Returns
+    -------
+    ndarray
+        `labels`, cast to `dtype`.
+
+    Raises
+    ------
+    ValueError
+        If any label is too large for `dtype`.
+    """
+
+    info = np.iinfo(dtype)
+    highest = int(labels.max()) if labels.size else 0
+    if highest > info.max:
+        message = (
+            f"The segmentation reaches label {highest}, more than the {dtype} "
+            f"segmentation layer can hold ({info.max})."
+        )
+        raise ValueError(f"{message} {remedy}".strip())
+    return labels.astype(dtype, copy=False)
 
 
 class _FloatEdit(QLineEdit):
@@ -152,8 +218,12 @@ class _SegmentationWorker(QThread):
 
     Parameters
     ----------
-    frame : ndarray
-        The single multichannel image to segment.
+    stack : ndarray or dask.array.Array
+        The stack the frame is read from. It is only materialised inside
+        :meth:`run`, so that a lazily loaded movie is read from disk on this
+        thread rather than freezing the viewer.
+    frame_index : int
+        Index of the frame to segment along the stack's first axis.
     prepared : PreparedSegmentationModel or None
         An already-prepared model to reuse; when None it is built from
         ``prepare_kwargs``.
@@ -169,9 +239,17 @@ class _SegmentationWorker(QThread):
     #: Emitted with the name of the phase being entered.
     stage = pyqtSignal(str)
 
-    def __init__(self, frame, prepared, prepare_kwargs: Dict[str, Any], parent=None):
+    def __init__(
+        self,
+        stack,
+        frame_index: int,
+        prepared,
+        prepare_kwargs: Dict[str, Any],
+        parent=None,
+    ):
         super().__init__(parent)
-        self._frame = frame
+        self._stack = stack
+        self._frame_index = frame_index
         self._prepared = prepared
         self._prepare_kwargs = prepare_kwargs
         self._cancelled = False
@@ -186,7 +264,7 @@ class _SegmentationWorker(QThread):
         return self._cancelled
 
     def run(self) -> None:
-        """Prepare the model if needed, then segment the frame."""
+        """Read the frame, prepare the model if needed, then segment."""
 
         from celldetective.segmentation import (
             prepare_segmentation_model,
@@ -194,6 +272,9 @@ class _SegmentationWorker(QThread):
         )
 
         try:
+            self.stage.emit("Reading the frame…")
+            frame = np.asarray(self._stack[self._frame_index])
+
             prepared = self._prepared
             if prepared is None:
                 self.stage.emit("Loading the model…")
@@ -211,7 +292,7 @@ class _SegmentationWorker(QThread):
                 return
 
             self.stage.emit("Segmenting the frame…")
-            labels = segment_frame(self._frame, prepared)
+            labels = segment_frame(frame, prepared)
         except ValueError as e:
             # Raised when none of the mapped channels reach the model.
             self.failed.emit(str(e))
@@ -251,14 +332,21 @@ class FrameSegmentationPanel(QWidget):
         self.position = position
         self.population = population
 
-        # One entry per (model, channel mapping, parameters) actually used, so
-        # that repeated runs with the same settings only pay for inference.
-        self._prepared: Dict[Any, Any] = {}
+        # Prepared models, most recently used last. Keyed only on what actually
+        # goes into building one -- the model, the channel mapping and the
+        # rescaling -- because the Cellpose thresholds are inference-time
+        # arguments and re-keying on them would reload a whole network every time
+        # a threshold is nudged. Bounded, since each entry is a full network.
+        self._prepared: "OrderedDict[Any, Any]" = OrderedDict()
 
-        # The run in flight, and what it was asked to do. Kept on the panel so
-        # the thread is not garbage collected while it works.
+        # The run in flight, and what it was asked to do.
         self._worker: Optional[_SegmentationWorker] = None
         self._pending: Optional[Dict[str, Any]] = None
+
+        # Set once the panel is being torn down, so a result that lands late is
+        # dropped instead of being written into a half-destroyed viewer.
+        self._closing = False
+        self._watched_window: Optional[QWidget] = None
 
         self.experiment = extract_experiment_from_position(position)
         try:
@@ -280,6 +368,42 @@ class FrameSegmentationPanel(QWidget):
         self.config: Optional[Dict[str, Any]] = None
 
         self._build()
+        self._install_close_hook()
+
+    def _install_close_hook(self) -> None:
+        """
+        Arrange for :meth:`closeEvent` to fire when the viewer window closes.
+
+        Qt delivers a close event to top-level windows only, and this panel lives
+        inside a dock widget, so on its own it would never see one: the viewer
+        would simply be destroyed underneath it, taking a running worker with it.
+        Watching the napari window for its own close event, and the application
+        for its shutdown, gives the panel the chance to stop that worker first.
+        """
+
+        try:
+            window = self.viewer.window._qt_window
+        except Exception as e:
+            logger.debug(f"Could not reach the napari window to watch it close: {e}")
+            window = None
+
+        if window is not None:
+            window.installEventFilter(self)
+            self._watched_window = window
+
+        app = QApplication.instance()
+        if app is not None:
+            app.aboutToQuit.connect(self._stop_worker)
+
+    def eventFilter(self, watched, event) -> bool:
+        """Turn the viewer window's close into this panel's own close."""
+        if (
+            watched is self._watched_window
+            and event.type() == QEvent.Close
+            and not self._closing
+        ):
+            self.close()
+        return super().eventFilter(watched, event)
 
     # ------------------------------------------------------------------
     # Construction
@@ -528,14 +652,53 @@ class FrameSegmentationPanel(QWidget):
             self.run_btn.setEnabled(bool(model_name) and model_name != NO_MODEL)
             self.status_lbl.setText("")
 
+    def _stop_worker(self) -> None:
+        """
+        Detach and wind down the run in flight, without ever blocking on it.
+
+        Inference cannot be interrupted, so the worker is asked to stop, given a
+        moment to reach the next phase boundary, and then simply let go of: its
+        signals are disconnected so nothing lands on a panel that is going away,
+        and `_LIVE_WORKERS` keeps the thread object alive until `run()` actually
+        returns. Waiting any longer would freeze the close; destroying the thread
+        instead would be a fatal error in Qt.
+        """
+
+        self._closing = True
+        worker = self._worker
+        self._worker = None
+        if worker is None:
+            return
+
+        worker.cancel()
+        try:
+            worker.stage.disconnect()
+            worker.succeeded.disconnect()
+            worker.failed.disconnect()
+        except (TypeError, RuntimeError) as e:
+            # Already disconnected, or the C++ object is gone: nothing to undo.
+            logger.debug(f"Could not disconnect the segmentation worker: {e}")
+
+        if worker.isRunning():
+            worker.wait(2000)
+        if worker.isRunning():
+            logger.info(
+                "Leaving a single-frame segmentation to finish in the background; "
+                "its result will be discarded."
+            )
+
     def closeEvent(self, event) -> None:
         """Stop a run in flight before the panel goes away."""
-        worker = self._worker
-        if worker is not None and worker.isRunning():
-            worker.cancel()
-            # Inference cannot be interrupted, so give it a moment to reach the
-            # next phase boundary rather than tearing the thread down under it.
-            worker.wait(5000)
+        self._stop_worker()
+        if self._watched_window is not None:
+            try:
+                self._watched_window.removeEventFilter(self)
+            except RuntimeError as e:
+                logger.debug(f"Watched window already destroyed: {e}")
+            self._watched_window = None
+        # Networks can be hundreds of MB each; do not keep them alive through a
+        # dangling reference to a closed panel.
+        self._prepared.clear()
         super().closeEvent(event)
 
     def _on_run_clicked(self) -> None:
@@ -582,16 +745,16 @@ class FrameSegmentationPanel(QWidget):
         cellprob = self.cellprob_le.value() if self.cellprob_le else None
         flow = self.flow_le.value() if self.flow_le else None
 
-        # Settings are part of the identity of a prepared model: changing the
-        # mapping or a threshold has to rebuild it, not reuse the last one.
+        # Only what the model is built from. The Cellpose thresholds and diameter
+        # are passed to inference, not to the constructor, so they are re-applied
+        # to a cached model instead of forcing it to be loaded again.
         cache_key = (
             model_name,
             tuple(selected) if selected is not None else None,
             target_cell_size,
-            diameter,
-            cellprob,
-            flow,
         )
+
+        cached = self._reuse_prepared(cache_key, diameter, cellprob, flow)
 
         # The GPU is left to napari's renderer: a single frame is quick on CPU,
         # and a TensorFlow context would compete for the VRAM the viewer is
@@ -610,12 +773,17 @@ class FrameSegmentationPanel(QWidget):
 
         self._pending = {"frame": t, "cache_key": cache_key, "model_name": model_name}
 
+        # Deliberately unparented: a QThread destroyed while running aborts the
+        # process, and a panel that is closing must be able to walk away from one.
         worker = _SegmentationWorker(
-            frame=np.asarray(self.stack[t]),
-            prepared=self._prepared.get(cache_key),
+            stack=self.stack,
+            frame_index=t,
+            prepared=cached,
             prepare_kwargs=prepare_kwargs,
-            parent=self,
         )
+        _LIVE_WORKERS.add(worker)
+        worker.finished.connect(lambda w=worker: _LIVE_WORKERS.discard(w))
+        worker.finished.connect(worker.deleteLater)
         worker.stage.connect(self._on_stage)
         worker.succeeded.connect(self._on_succeeded)
         worker.failed.connect(self._on_failed)
@@ -626,6 +794,65 @@ class FrameSegmentationPanel(QWidget):
         self.status_lbl.setText("Starting…")
         self.viewer.status = f"Segmenting frame {t} with '{model_name}'…"
         worker.start()
+
+    def _reuse_prepared(
+        self,
+        cache_key,
+        diameter: Optional[float],
+        cellprob: Optional[float],
+        flow: Optional[float],
+    ):
+        """
+        Fetch a prepared model for these settings and re-apply the inference values.
+
+        The Cellpose diameter and thresholds are arguments to the forward pass, not
+        to the constructor, so a change to any of them only has to be written onto
+        the model rather than causing a new one to be loaded. A field left blank
+        means "use the model's own value", which is what
+        ``PreparedSegmentationModel.config_defaults`` holds.
+
+        Parameters
+        ----------
+        cache_key : tuple
+            Identity of the model to look up.
+        diameter, cellprob, flow : float or None
+            The values entered in the panel, None meaning the model's own.
+
+        Returns
+        -------
+        PreparedSegmentationModel or None
+            The cached model, updated in place, or None when there is no hit.
+        """
+
+        prepared = self._prepared.get(cache_key)
+        if prepared is None:
+            return None
+
+        # Most recently used last, so the eviction below drops the coldest entry.
+        self._prepared.move_to_end(cache_key)
+
+        if prepared.model_type == "cellpose":
+            defaults = prepared.config_defaults
+            prepared.diameter = (
+                diameter if diameter is not None else defaults.get("diameter")
+            )
+            prepared.cellprob_threshold = (
+                cellprob
+                if cellprob is not None
+                else defaults.get("cellprob_threshold")
+            )
+            prepared.flow_threshold = (
+                flow if flow is not None else defaults.get("flow_threshold")
+            )
+        return prepared
+
+    def _cache_prepared(self, cache_key, prepared) -> None:
+        """Store a prepared model, evicting the coldest once the cache is full."""
+        self._prepared[cache_key] = prepared
+        self._prepared.move_to_end(cache_key)
+        while len(self._prepared) > MAX_CACHED_MODELS:
+            evicted, _ = self._prepared.popitem(last=False)
+            logger.debug(f"Dropped the cached segmentation model for {evicted}.")
 
     def _on_stage(self, message: str) -> None:
         """Show the phase the worker has entered."""
@@ -638,12 +865,81 @@ class FrameSegmentationPanel(QWidget):
 
     def _on_worker_finished(self) -> None:
         """Return the panel to its idle state once the thread has ended."""
+        if self._closing:
+            return
         cancelled = self._worker is not None and self._worker.cancelled
         self._worker = None
         self._set_running(False)
         if cancelled:
             self.viewer.status = "Segmentation cancelled."
             logger.info("Single-frame segmentation cancelled.")
+
+    def _merged_labels(self, current: np.ndarray, new_labels: np.ndarray) -> np.ndarray:
+        """
+        Combine new labels with the ones already drawn on the frame.
+
+        The incoming labels are pushed past the highest existing one so the two
+        sets cannot collide, and only fill background, so manual corrections
+        survive.
+
+        Parameters
+        ----------
+        current : ndarray
+            The labels currently on the frame.
+        new_labels : ndarray
+            The labels the model produced.
+
+        Returns
+        -------
+        ndarray
+            The merged labels, in `current`'s dtype.
+
+        Raises
+        ------
+        ValueError
+            If the merged labels would not fit the layer's integer type. Wrapping
+            round silently would merge unrelated cells under one identifier.
+        """
+
+        offset = int(current.max())
+        # int64 throughout: `new_labels` is typically uint16, and adding the offset
+        # in its own dtype wraps round without a word of warning.
+        incoming = np.where(new_labels > 0, new_labels.astype(np.int64) + offset, 0)
+        merged = np.where(current > 0, current.astype(np.int64), incoming)
+        return _fit_to_layer_dtype(
+            merged,
+            current.dtype,
+            "Tick 'Replace the labels on this frame' to segment it afresh.",
+        )
+
+    def _record_undo(self, layer, t: int, before: np.ndarray, after: np.ndarray) -> None:
+        """
+        Push this write onto the labels layer's undo history, if napari lets us.
+
+        Without this the frame can be segmented but not un-segmented: napari only
+        records what its own painting tools do, so a bulk write would leave Ctrl+Z
+        undoing whatever the user had done before instead. Best-effort - the
+        history is private API, so a napari that has moved it simply gets no undo
+        step rather than an error.
+
+        Parameters
+        ----------
+        layer : napari.layers.Labels
+            The layer being written to.
+        t : int
+            Index of the frame that changed.
+        before, after : ndarray
+            The frame's labels either side of the write.
+        """
+
+        try:
+            changed = np.nonzero(before != after)
+            if len(changed[0]) == 0:
+                return
+            indices = (np.full(changed[0].shape, t, dtype=np.intp),) + changed
+            layer._save_history((indices, before[changed], after[changed]))
+        except Exception as e:
+            logger.debug(f"Could not record an undo step for the segmentation: {e}")
 
     def _on_succeeded(self, prepared, new_labels) -> None:
         """
@@ -657,12 +953,15 @@ class FrameSegmentationPanel(QWidget):
             The labels for the frame that was segmented.
         """
 
+        if self._closing:
+            return
+
         pending = self._pending or {}
         t = pending.get("frame", 0)
         model_name = pending.get("model_name", "")
         cache_key = pending.get("cache_key")
         if cache_key is not None:
-            self._prepared[cache_key] = prepared
+            self._cache_prepared(cache_key, prepared)
 
         # The viewer may have been closed while the worker was running.
         try:
@@ -673,20 +972,26 @@ class FrameSegmentationPanel(QWidget):
 
         try:
             current = layer.data[t]
+            before = current.copy()
             if self.replace_cb.isChecked():
-                current[...] = new_labels
+                merged = _fit_to_layer_dtype(new_labels, current.dtype)
             else:
-                # Offset the incoming labels past the ones already drawn so the
-                # two sets cannot collide, then keep whatever was already there.
-                offset = int(current.max())
-                incoming = np.where(new_labels > 0, new_labels + offset, 0)
-                current[...] = np.where(current > 0, current, incoming)
+                merged = self._merged_labels(current, new_labels)
+            current[...] = merged
+        except ValueError as e:
+            # Raised when the labels will not fit the layer's integer type.
+            self._failed(str(e))
+            return
         except Exception as e:
             self._failed(f"Could not write the labels into the viewer: {e}")
             return
+
+        self._record_undo(layer, t, before, layer.data[t])
         layer.refresh()
 
-        n_objects = int(np.max(layer.data[t]))
+        # Count the objects rather than reading the highest label: in merge mode
+        # the incoming labels are offset, so the maximum is not a count.
+        n_objects = int(np.count_nonzero(np.unique(layer.data[t])))
         message = f"Frame {t}: {n_objects} objects after segmenting with '{model_name}'."
         self.viewer.status = message
         logger.info(message)

--- a/celldetective/napari/frame_segmentation.py
+++ b/celldetective/napari/frame_segmentation.py
@@ -16,7 +16,7 @@ from collections import OrderedDict
 from typing import Any, Dict, List, Optional, Set
 
 import numpy as np
-from PyQt5.QtCore import QEvent, Qt, QThread, pyqtSignal
+from PyQt5.QtCore import QEvent, Qt, QThread, QTimer, pyqtSignal
 from PyQt5.QtGui import QDoubleValidator
 from PyQt5.QtWidgets import (
     QApplication,
@@ -188,9 +188,20 @@ def _fit_to_layer_dtype(
 class _FloatEdit(QLineEdit):
     """A line edit accepting a single float, blank meaning "use the model's value"."""
 
-    def __init__(self, value: Optional[float] = None, parent=None):
+    def __init__(
+        self,
+        value: Optional[float] = None,
+        parent=None,
+        bottom: Optional[float] = None,
+    ):
         super().__init__(parent)
-        self.setValidator(QDoubleValidator())
+        validator = QDoubleValidator()
+        if bottom is not None:
+            # Keeps a negative out of the field entirely; a value of exactly the
+            # bottom still gets through, so anything that must be strictly greater
+            # is checked again before the run starts.
+            validator.setBottom(bottom)
+        self.setValidator(validator)
         if value is not None:
             self.setText(str(value))
 
@@ -402,8 +413,27 @@ class FrameSegmentationPanel(QWidget):
             and event.type() == QEvent.Close
             and not self._closing
         ):
-            self.close()
+            # An event filter runs *before* the window's own `closeEvent`, and
+            # napari's asks for confirmation: the user may still call the close
+            # off, in which case the viewer stays open and this panel must stay
+            # with it. Settle it on the next trip through the event loop, once
+            # the window has had its say.
+            QTimer.singleShot(0, self._close_if_window_closed)
         return super().eventFilter(watched, event)
+
+    def _close_if_window_closed(self) -> None:
+        """Close the panel, but only if the viewer window really did close."""
+
+        window = self._watched_window
+        if window is None:
+            return
+        try:
+            still_open = window.isVisible()
+        except RuntimeError:
+            # The C++ window is already gone, so the close went through.
+            still_open = False
+        if not still_open:
+            self.close()
 
     # ------------------------------------------------------------------
     # Construction
@@ -567,7 +597,7 @@ class FrameSegmentationPanel(QWidget):
         if "cell_size_um" in self.config:
             trained = self.config["cell_size_um"]
             self.cell_size_le = _FloatEdit(
-                self.config.get("target_cell_size_um", trained)
+                self.config.get("target_cell_size_um", trained), bottom=0.0
             )
             self.cell_size_le.setToolTip(
                 f"Typical object size in these images, in µm.\n"
@@ -701,6 +731,15 @@ class FrameSegmentationPanel(QWidget):
         self._prepared.clear()
         super().closeEvent(event)
 
+    def showEvent(self, event) -> None:
+        """Bring the panel back to life if it is shown again after a close."""
+        # `_stop_worker` latches `_closing` so that a result landing mid-teardown
+        # is dropped rather than pushed into a dying viewer. A panel that is on
+        # screen again is not dying, and leaving the latch set would make every
+        # later run hang with its labels silently discarded.
+        self._closing = False
+        super().showEvent(event)
+
     def _on_run_clicked(self) -> None:
         """Start a segmentation, or cancel the one in flight."""
         if self._worker is not None and self._worker.isRunning():
@@ -741,6 +780,13 @@ class FrameSegmentationPanel(QWidget):
         t = int(self.viewer.dims.current_step[0])
 
         target_cell_size = self.cell_size_le.value() if self.cell_size_le else None
+        if target_cell_size is not None and target_cell_size <= 0:
+            self._failed(
+                "The cell size must be greater than zero. Clear the field to use "
+                "the model's own value."
+            )
+            return
+
         diameter = self.diameter_le.value() if self.diameter_le else None
         cellprob = self.cellprob_le.value() if self.cellprob_le else None
         flow = self.flow_le.value() if self.flow_le else None
@@ -764,6 +810,10 @@ class FrameSegmentationPanel(QWidget):
             channels=self.exp_channels or None,
             spatial_calibration=self.spatial_calibration,
             use_gpu=False,
+            # The panel mirrors the main window, so it opts in to the mapping the
+            # channel-selection dialog stored: with no channel rows yet (a model
+            # fetched on this very run) that is what the pipeline would use.
+            use_stored_mapping=True,
             selected_channels=selected,
             target_cell_size=target_cell_size,
             diameter=diameter,
@@ -962,6 +1012,23 @@ class FrameSegmentationPanel(QWidget):
         cache_key = pending.get("cache_key")
         if cache_key is not None:
             self._cache_prepared(cache_key, prepared)
+
+        # A model fetched during this very run: its configuration only reached the
+        # disk once the worker had started, so the panel is still showing the
+        # "not downloaded yet" placeholder with no channel or parameter rows.
+        # Build them now, rather than leaving the user to cycle the dropdown to
+        # get at a mapping the model has had all along.
+        if (
+            self.config is None
+            and model_name
+            and model_name == self.model_cb.currentText()
+        ):
+            self._reload_model(model_name)
+            if self.config is not None and cache_key is not None:
+                # Those rows feed the cache key, so the entry just stored is keyed
+                # on a state that can never come back; drop it rather than hold a
+                # few hundred MB of network alive for a key nothing will ask for.
+                self._prepared.pop(cache_key, None)
 
         # The viewer may have been closed while the worker was running.
         try:

--- a/celldetective/napari/frame_segmentation.py
+++ b/celldetective/napari/frame_segmentation.py
@@ -721,17 +721,26 @@ class FrameSegmentationPanel(QWidget):
             return
 
         worker.cancel()
-        try:
-            worker.stage.disconnect()
-            worker.succeeded.disconnect()
-            worker.failed.disconnect()
-            # `finished` too: `showEvent` clears `_closing`, so a panel shown
-            # again would let a detached worker's `finished` run, dropping
-            # `_worker` and flipping the UI back to idle underneath a newer run.
-            worker.finished.disconnect()
-        except (TypeError, RuntimeError) as e:
-            # Already disconnected, or the C++ object is gone: nothing to undo.
-            logger.debug(f"Could not disconnect the segmentation worker: {e}")
+        # Slot by slot, never a bare `disconnect()`: the worker also carries the
+        # bookkeeping this panel does not own -- discarding itself from
+        # `_LIVE_WORKERS` and its own `deleteLater` -- and clearing a signal
+        # wholesale would drop those too, stranding a still-running worker (and
+        # the stack and network it holds) for the life of the process.
+        # `finished` is detached like the rest: `showEvent` clears `_closing`, so
+        # a panel shown again would otherwise let a detached worker's `finished`
+        # run, dropping `_worker` and flipping the UI back to idle underneath a
+        # newer run.
+        for signal, slot in (
+            (worker.stage, self._on_stage),
+            (worker.succeeded, self._on_succeeded),
+            (worker.failed, self._on_failed),
+            (worker.finished, self._on_worker_finished),
+        ):
+            try:
+                signal.disconnect(slot)
+            except (TypeError, RuntimeError) as e:
+                # Already disconnected, or the C++ object is gone: nothing to undo.
+                logger.debug(f"Could not disconnect the segmentation worker: {e}")
 
         if worker.isRunning():
             worker.wait(2000)

--- a/celldetective/napari/frame_segmentation.py
+++ b/celldetective/napari/frame_segmentation.py
@@ -1,9 +1,10 @@
 """
 Segment the frame on screen, from inside the napari correction viewer.
 
-The panel mirrors the channel-selection dialog of the main window: one dropdown
-per input slot of the chosen model, plus whatever inference parameters that
-model type actually takes. Values are seeded from the model's
+The panel embeds the very channel-selection widget the main window is built on
+-- :class:`~celldetective.gui.base.model_channel_selection.ModelChannelSelection`,
+one dropdown per input slot of the chosen model -- and adds whatever inference
+parameters that model type actually takes. Values are seeded from the model's
 ``config_input.json`` -- including any ``selected_channels`` mapping already set
 in the main window -- but edits stay local to the napari session and are never
 written back, so trying settings out here cannot silently change the next
@@ -35,6 +36,7 @@ from PyQt5.QtWidgets import (
 )
 
 from celldetective import get_logger
+from celldetective.gui.base.model_channel_selection import ModelChannelSelection
 from celldetective.utils.experiment import (
     extract_experiment_channels,
     extract_experiment_from_position,
@@ -47,10 +49,6 @@ logger = get_logger(__name__)
 # Offered in the model dropdown when nothing is installed, so that the panel --
 # and with it the whole viewer -- still builds.
 NO_MODEL = "(no segmentation model found)"
-
-# The channel-selection dialog uses this spelling for an unused input slot, and
-# it is what ends up in `selected_channels`, so match it exactly.
-NO_CHANNEL = "None"
 
 # How many prepared models the panel keeps alive at once. Each one is a whole
 # StarDist / Cellpose network, so the cache trades a few hundred MB for not
@@ -371,7 +369,7 @@ class FrameSegmentationPanel(QWidget):
             logger.warning(f"Could not read the spatial calibration: {e}")
             self.spatial_calibration = None
 
-        self.channel_cbs: List[QComboBox] = []
+        self.channel_selection: Optional[ModelChannelSelection] = None
         self.diameter_le: Optional[_FloatEdit] = None
         self.cellprob_le: Optional[_FloatEdit] = None
         self.flow_le: Optional[_FloatEdit] = None
@@ -457,8 +455,8 @@ class FrameSegmentationPanel(QWidget):
         outer.addLayout(model_row)
 
         self.channel_box = QGroupBox("channels")
-        self.channel_form = QFormLayout(self.channel_box)
-        self.channel_form.setContentsMargins(8, 8, 8, 8)
+        self.channel_layout = QVBoxLayout(self.channel_box)
+        self.channel_layout.setContentsMargins(8, 8, 8, 8)
         outer.addWidget(self.channel_box)
 
         self.param_box = QGroupBox("parameters")
@@ -495,12 +493,16 @@ class FrameSegmentationPanel(QWidget):
         self.model_cb.currentTextChanged.connect(self._reload_model)
         self._reload_model(self.model_cb.currentText())
 
-    def _clear(self, form: QFormLayout) -> None:
-        """Remove every row from a form layout."""
-        while form.count():
-            item = form.takeAt(0)
+    def _clear(self, layout) -> None:
+        """Remove every row from a layout, deleting the widgets it held."""
+        while layout.count():
+            item = layout.takeAt(0)
             widget = item.widget()
             if widget is not None:
+                # Unparent first: `deleteLater` only schedules the deletion, and
+                # until it runs the widget would still be shown by the box it was
+                # just taken out of.
+                widget.setParent(None)
                 widget.deleteLater()
 
     def _reload_model(self, model_name: str) -> None:
@@ -513,9 +515,9 @@ class FrameSegmentationPanel(QWidget):
             The newly selected model.
         """
 
-        self._clear(self.channel_form)
+        self._clear(self.channel_layout)
         self._clear(self.param_form)
-        self.channel_cbs = []
+        self.channel_selection = None
         self.diameter_le = None
         self.cellprob_le = None
         self.flow_le = None
@@ -523,7 +525,7 @@ class FrameSegmentationPanel(QWidget):
 
         if not model_name or model_name == NO_MODEL:
             self.config = None
-            self.channel_form.addRow(QLabel("No model available."))
+            self.channel_layout.addWidget(QLabel("No model available."))
             self.run_btn.setEnabled(False)
             return
 
@@ -533,7 +535,7 @@ class FrameSegmentationPanel(QWidget):
         if self.config is None:
             # A repository model that has not been fetched yet: its channels and
             # parameters are unknown until it lands on disk.
-            self.channel_form.addRow(
+            self.channel_layout.addWidget(
                 QLabel("Not downloaded yet.\nIt will be fetched on the first run,\nusing the model's own settings.")
             )
             return
@@ -542,33 +544,23 @@ class FrameSegmentationPanel(QWidget):
         self._build_parameter_rows()
 
     def _build_channel_rows(self) -> None:
-        """One dropdown per model input slot, seeded from the stored mapping."""
+        """
+        One dropdown per model input slot, seeded from the stored mapping.
 
-        required = list(self.config.get("channels", []))
+        The rows are the main window's own channel-selection widget, so a model's
+        inputs are mapped the same way wherever it is run from -- including the
+        ``selected_channels`` mapping already saved there, which is what makes a
+        model like ``CP_cyto3`` usable at all: it declares channel names no real
+        experiment is named after.
+        """
+
         stored = self.config.get("selected_channels")
-        options = list(self.exp_channels) + [NO_CHANNEL]
-
-        for i, slot in enumerate(required):
-            combo = QComboBox()
-            combo.addItems(options)
-            combo.setToolTip(f"Experiment channel feeding the model's '{slot}' input.")
-
-            # Prefer the mapping the main window already saved, then a plain name
-            # match, and leave the slot empty when neither is available.
-            default = None
-            if isinstance(stored, list) and i < len(stored):
-                default = stored[i]
-            if default is None or combo.findText(str(default)) < 0:
-                default = slot if slot in self.exp_channels else NO_CHANNEL
-
-            idx = combo.findText(str(default))
-            combo.setCurrentIndex(idx if idx >= 0 else len(options) - 1)
-
-            self.channel_cbs.append(combo)
-            self.channel_form.addRow(QLabel(f"{slot}:"), combo)
-
-        if not required:
-            self.channel_form.addRow(QLabel("This model declares no input channels."))
+        self.channel_selection = ModelChannelSelection(
+            required_channels=list(self.config.get("channels", [])),
+            available_channels=self.exp_channels,
+            selected_channels=stored if isinstance(stored, list) else None,
+        )
+        self.channel_layout.addWidget(self.channel_selection)
 
     def _build_parameter_rows(self) -> None:
         """Expose the inference parameters that this model type actually takes."""
@@ -617,9 +609,9 @@ class FrameSegmentationPanel(QWidget):
 
     def _selected_channels(self) -> Optional[List[str]]:
         """The channel mapping as currently set, or None when the model is unknown."""
-        if not self.channel_cbs:
+        if self.channel_selection is None:
             return None
-        return [combo.currentText() for combo in self.channel_cbs]
+        return self.channel_selection.selected_channels() or None
 
     def _failed(self, message: str) -> None:
         """
@@ -655,8 +647,8 @@ class FrameSegmentationPanel(QWidget):
 
         self.model_cb.setEnabled(not running)
         self.replace_cb.setEnabled(not running)
-        for combo in self.channel_cbs:
-            combo.setEnabled(not running)
+        if self.channel_selection is not None:
+            self.channel_selection.setEnabled(not running)
         for edit in (
             self.diameter_le,
             self.cellprob_le,
@@ -770,7 +762,7 @@ class FrameSegmentationPanel(QWidget):
             return
 
         selected = self._selected_channels()
-        if selected is not None and all(ch == NO_CHANNEL for ch in selected):
+        if self.channel_selection is not None and self.channel_selection.is_empty():
             self._failed(
                 "Every input channel is set to None. Assign at least one experiment "
                 "channel to a model input."

--- a/celldetective/napari/utils.py
+++ b/celldetective/napari/utils.py
@@ -31,6 +31,7 @@ from celldetective.utils.experiment import (
     get_experiment_labels,
     get_experiment_metadata,
     extract_experiment_channels,
+    get_spatial_calibration,
 )
 from celldetective.utils.parsing import config_section_to_dict
 from celldetective import get_logger
@@ -1347,6 +1348,162 @@ def launch_segmentation_viewer(
         """Widget to trigger export."""
         return export_annotation()
 
+    # ------------------------------------------------------------------
+    # Segment the frame currently on screen
+    # ------------------------------------------------------------------
+
+    # Loading a segmentation model costs seconds; keep each one alive for as
+    # long as the viewer is open so that repeated calls only pay for inference.
+    prepared_models: Dict[str, Any] = {}
+
+    def _available_segmentation_models() -> List[str]:
+        """
+        List the models offered in the dropdown: population-specific, then generic.
+
+        Returns
+        -------
+        list of str
+            Model names, without duplicates, in the order they are offered.
+        """
+
+        from celldetective.utils.model_getters import get_segmentation_models_list
+
+        models: List[str] = []
+        for mode in (population, "generic"):
+            try:
+                models.extend(
+                    get_segmentation_models_list(mode=mode, return_path=False)
+                )
+            except Exception as e:
+                # Listing reaches out to the model repository; a network failure
+                # must not stop the viewer from opening.
+                logger.warning(f"Could not list the '{mode}' segmentation models: {e}")
+
+        seen = set()
+        return [m for m in models if not (m in seen or seen.add(m))]
+
+    def _segmentation_failed(message: str) -> None:
+        """
+        Report a segmentation failure without tearing down the viewer.
+
+        Parameters
+        ----------
+        message : str
+            The message shown to the user and written to the log.
+        """
+
+        logger.error(message)
+        viewer.status = message
+        try:
+            box = QMessageBox()
+            box.setIcon(QMessageBox.Warning)
+            box.setText(message)
+            box.setWindowTitle("Segmentation")
+            box.setStandardButtons(QMessageBox.Ok)
+            box.exec_()
+        except Exception as e:
+            logger.debug(f"Could not show the segmentation error dialog: {e}")
+
+    @magicgui(
+        call_button="Segment this frame",
+        model={"label": "model", "choices": _available_segmentation_models()},
+        replace_existing={
+            "widget_type": "CheckBox",
+            "text": "Replace the labels on this frame",
+        },
+    )
+    def segment_frame_widget(model: str, replace_existing: bool = True) -> None:
+        """
+        Segment the frame currently displayed, using the selected model.
+
+        Runs on the frame the time slider is on, writes the result straight into
+        the segmentation layer, and leaves every other frame untouched. Nothing
+        is written to disk until the labels are saved.
+
+        Parameters
+        ----------
+        model : str
+            Name of the segmentation model to run.
+        replace_existing : bool, optional
+            If True, the labels on this frame are replaced. If False, existing
+            labels are kept and the new ones only fill the background, so manual
+            corrections survive. The default is True.
+        """
+
+        from PyQt5.QtCore import Qt
+        from PyQt5.QtWidgets import QApplication
+
+        if not model:
+            _segmentation_failed(
+                "No segmentation model is available. Download or train one first."
+            )
+            return
+
+        t = int(viewer.dims.current_step[0])
+        experiment = extract_experiment_from_position(position)
+
+        try:
+            channel_names, _ = extract_experiment_channels(experiment)
+            channel_names = list(channel_names)
+            spatial_calibration = get_spatial_calibration(experiment)
+        except Exception as e:
+            _segmentation_failed(f"Could not read the experiment configuration: {e}")
+            return
+
+        QApplication.setOverrideCursor(Qt.WaitCursor)
+        viewer.status = f"Segmenting frame {t} with '{model}'…"
+        try:
+            prepared = prepared_models.get(model)
+            if prepared is None:
+                from celldetective.segmentation import prepare_segmentation_model
+
+                # The GPU is left to napari's renderer: a single frame is quick
+                # on CPU, and a TensorFlow context would compete for the VRAM
+                # the viewer is already using.
+                prepared = prepare_segmentation_model(
+                    model,
+                    channels=channel_names,
+                    spatial_calibration=spatial_calibration,
+                    use_gpu=False,
+                )
+                if prepared is None:
+                    _segmentation_failed(
+                        f"Model '{model}' could not be loaded. See the log for details."
+                    )
+                    return
+                prepared_models[model] = prepared
+
+            from celldetective.segmentation import segment_frame
+
+            new_labels = segment_frame(np.asarray(stack[t]), prepared)
+        except Exception as e:
+            logger.exception("Single-frame segmentation failed.")
+            _segmentation_failed(f"Segmentation failed: {e}")
+            return
+        finally:
+            QApplication.restoreOverrideCursor()
+
+        layer = viewer.layers["segmentation"]
+        try:
+            current = layer.data[t]
+            if replace_existing:
+                current[...] = new_labels
+            else:
+                # Offset the new labels past the ones already drawn so the two
+                # sets cannot collide, then keep whatever was already there.
+                offset = int(current.max())
+                incoming = np.where(new_labels > 0, new_labels + offset, 0)
+                current[...] = np.where(current > 0, current, incoming)
+        except Exception as e:
+            _segmentation_failed(f"Could not write the labels into the viewer: {e}")
+            return
+        layer.refresh()
+
+        n_objects = int(np.max(layer.data[t]))
+        message = f"Frame {t}: {n_objects} objects after segmenting with '{model}'."
+        viewer.status = message
+        logger.info(message)
+
     if contrast_limits is None:
         contrast_limits = _get_contrast_limits(stack)
 
@@ -1378,12 +1535,19 @@ def launch_segmentation_viewer(
     button_container = QWidget()
     layout = QVBoxLayout(button_container)
     layout.setSpacing(10)
+    layout.addWidget(segment_frame_widget.native)
     layout.addWidget(correction_options.native)
     layout.addWidget(save_widget.native)
     layout.addWidget(export_widget.native)
     viewer.window.add_dock_widget(button_container, area="right")
 
     save_widget.native.setStyleSheet(Styles().button_style_sheet)
+    try:
+        segment_frame_widget.call_button.native.setStyleSheet(
+            Styles().button_style_sheet
+        )
+    except Exception as e:
+        logger.debug(f"Could not style the segmentation button: {e}")
     export_widget.native.setStyleSheet(Styles().button_style_sheet)
 
     def lock_controls(

--- a/celldetective/napari/utils.py
+++ b/celldetective/napari/utils.py
@@ -40,6 +40,9 @@ from celldetective.gui.base.styles import Styles
 
 logger = get_logger()
 
+# Shown in the napari "segment this frame" dropdown when no model is installed.
+_NO_SEGMENTATION_MODEL = "(no segmentation model found)"
+
 
 def _drop_fully_maskless_tracks(df: pd.DataFrame) -> pd.DataFrame:
     """
@@ -1380,7 +1383,12 @@ def launch_segmentation_viewer(
                 logger.warning(f"Could not list the '{mode}' segmentation models: {e}")
 
         seen = set()
-        return [m for m in models if not (m in seen or seen.add(m))]
+        models = [m for m in models if not (m in seen or seen.add(m))]
+
+        # magicgui cannot build a dropdown from an empty list, and raising here
+        # would stop the whole viewer from opening. Offer a placeholder instead;
+        # the callback below refuses to run on it.
+        return models or [_NO_SEGMENTATION_MODEL]
 
     def _segmentation_failed(message: str) -> None:
         """
@@ -1433,7 +1441,7 @@ def launch_segmentation_viewer(
         from PyQt5.QtCore import Qt
         from PyQt5.QtWidgets import QApplication
 
-        if not model:
+        if not model or model == _NO_SEGMENTATION_MODEL:
             _segmentation_failed(
                 "No segmentation model is available. Download or train one first."
             )

--- a/celldetective/napari/utils.py
+++ b/celldetective/napari/utils.py
@@ -40,9 +40,6 @@ from celldetective.gui.base.styles import Styles
 
 logger = get_logger()
 
-# Shown in the napari "segment this frame" dropdown when no model is installed.
-_NO_SEGMENTATION_MODEL = "(no segmentation model found)"
-
 
 def _drop_fully_maskless_tracks(df: pd.DataFrame) -> pd.DataFrame:
     """
@@ -1351,167 +1348,6 @@ def launch_segmentation_viewer(
         """Widget to trigger export."""
         return export_annotation()
 
-    # ------------------------------------------------------------------
-    # Segment the frame currently on screen
-    # ------------------------------------------------------------------
-
-    # Loading a segmentation model costs seconds; keep each one alive for as
-    # long as the viewer is open so that repeated calls only pay for inference.
-    prepared_models: Dict[str, Any] = {}
-
-    def _available_segmentation_models() -> List[str]:
-        """
-        List the models offered in the dropdown: population-specific, then generic.
-
-        Returns
-        -------
-        list of str
-            Model names, without duplicates, in the order they are offered.
-        """
-
-        from celldetective.utils.model_getters import get_segmentation_models_list
-
-        models: List[str] = []
-        for mode in (population, "generic"):
-            try:
-                models.extend(
-                    get_segmentation_models_list(mode=mode, return_path=False)
-                )
-            except Exception as e:
-                # Listing reaches out to the model repository; a network failure
-                # must not stop the viewer from opening.
-                logger.warning(f"Could not list the '{mode}' segmentation models: {e}")
-
-        seen = set()
-        models = [m for m in models if not (m in seen or seen.add(m))]
-
-        # magicgui cannot build a dropdown from an empty list, and raising here
-        # would stop the whole viewer from opening. Offer a placeholder instead;
-        # the callback below refuses to run on it.
-        return models or [_NO_SEGMENTATION_MODEL]
-
-    def _segmentation_failed(message: str) -> None:
-        """
-        Report a segmentation failure without tearing down the viewer.
-
-        Parameters
-        ----------
-        message : str
-            The message shown to the user and written to the log.
-        """
-
-        logger.error(message)
-        viewer.status = message
-        try:
-            box = QMessageBox()
-            box.setIcon(QMessageBox.Warning)
-            box.setText(message)
-            box.setWindowTitle("Segmentation")
-            box.setStandardButtons(QMessageBox.Ok)
-            box.exec_()
-        except Exception as e:
-            logger.debug(f"Could not show the segmentation error dialog: {e}")
-
-    @magicgui(
-        call_button="Segment this frame",
-        model={"label": "model", "choices": _available_segmentation_models()},
-        replace_existing={
-            "widget_type": "CheckBox",
-            "text": "Replace the labels on this frame",
-        },
-    )
-    def segment_frame_widget(model: str, replace_existing: bool = True) -> None:
-        """
-        Segment the frame currently displayed, using the selected model.
-
-        Runs on the frame the time slider is on, writes the result straight into
-        the segmentation layer, and leaves every other frame untouched. Nothing
-        is written to disk until the labels are saved.
-
-        Parameters
-        ----------
-        model : str
-            Name of the segmentation model to run.
-        replace_existing : bool, optional
-            If True, the labels on this frame are replaced. If False, existing
-            labels are kept and the new ones only fill the background, so manual
-            corrections survive. The default is True.
-        """
-
-        from PyQt5.QtCore import Qt
-        from PyQt5.QtWidgets import QApplication
-
-        if not model or model == _NO_SEGMENTATION_MODEL:
-            _segmentation_failed(
-                "No segmentation model is available. Download or train one first."
-            )
-            return
-
-        t = int(viewer.dims.current_step[0])
-        experiment = extract_experiment_from_position(position)
-
-        try:
-            channel_names, _ = extract_experiment_channels(experiment)
-            channel_names = list(channel_names)
-            spatial_calibration = get_spatial_calibration(experiment)
-        except Exception as e:
-            _segmentation_failed(f"Could not read the experiment configuration: {e}")
-            return
-
-        QApplication.setOverrideCursor(Qt.WaitCursor)
-        viewer.status = f"Segmenting frame {t} with '{model}'…"
-        try:
-            prepared = prepared_models.get(model)
-            if prepared is None:
-                from celldetective.segmentation import prepare_segmentation_model
-
-                # The GPU is left to napari's renderer: a single frame is quick
-                # on CPU, and a TensorFlow context would compete for the VRAM
-                # the viewer is already using.
-                prepared = prepare_segmentation_model(
-                    model,
-                    channels=channel_names,
-                    spatial_calibration=spatial_calibration,
-                    use_gpu=False,
-                )
-                if prepared is None:
-                    _segmentation_failed(
-                        f"Model '{model}' could not be loaded. See the log for details."
-                    )
-                    return
-                prepared_models[model] = prepared
-
-            from celldetective.segmentation import segment_frame
-
-            new_labels = segment_frame(np.asarray(stack[t]), prepared)
-        except Exception as e:
-            logger.exception("Single-frame segmentation failed.")
-            _segmentation_failed(f"Segmentation failed: {e}")
-            return
-        finally:
-            QApplication.restoreOverrideCursor()
-
-        layer = viewer.layers["segmentation"]
-        try:
-            current = layer.data[t]
-            if replace_existing:
-                current[...] = new_labels
-            else:
-                # Offset the new labels past the ones already drawn so the two
-                # sets cannot collide, then keep whatever was already there.
-                offset = int(current.max())
-                incoming = np.where(new_labels > 0, new_labels + offset, 0)
-                current[...] = np.where(current > 0, current, incoming)
-        except Exception as e:
-            _segmentation_failed(f"Could not write the labels into the viewer: {e}")
-            return
-        layer.refresh()
-
-        n_objects = int(np.max(layer.data[t]))
-        message = f"Frame {t}: {n_objects} objects after segmenting with '{model}'."
-        viewer.status = message
-        logger.info(message)
-
     if contrast_limits is None:
         contrast_limits = _get_contrast_limits(stack)
 
@@ -1540,22 +1376,30 @@ def launch_segmentation_viewer(
         labels = labels.astype(np.int32)
     viewer.add_labels(labels, name="segmentation", opacity=0.4)
 
+    # A panel that cannot be built must not stop the viewer from opening.
+    try:
+        from celldetective.napari.frame_segmentation import FrameSegmentationPanel
+
+        segment_frame_panel = FrameSegmentationPanel(
+            viewer=viewer, stack=stack, position=position, population=population
+        )
+    except Exception:
+        logger.exception("Could not build the single-frame segmentation panel.")
+        segment_frame_panel = None
+
     button_container = QWidget()
     layout = QVBoxLayout(button_container)
     layout.setSpacing(10)
-    layout.addWidget(segment_frame_widget.native)
+    if segment_frame_panel is not None:
+        layout.addWidget(segment_frame_panel)
     layout.addWidget(correction_options.native)
     layout.addWidget(save_widget.native)
     layout.addWidget(export_widget.native)
     viewer.window.add_dock_widget(button_container, area="right")
 
     save_widget.native.setStyleSheet(Styles().button_style_sheet)
-    try:
-        segment_frame_widget.call_button.native.setStyleSheet(
-            Styles().button_style_sheet
-        )
-    except Exception as e:
-        logger.debug(f"Could not style the segmentation button: {e}")
+    if segment_frame_panel is not None:
+        segment_frame_panel.run_btn.setStyleSheet(Styles().button_style_sheet)
     export_widget.native.setStyleSheet(Styles().button_style_sheet)
 
     def lock_controls(

--- a/celldetective/processes/segment_cells.py
+++ b/celldetective/processes/segment_cells.py
@@ -23,7 +23,7 @@ from celldetective.utils.image_loaders import (
     _load_frames_to_segment,
     load_frames,
 )
-from celldetective.utils.image_transforms import _estimate_scale_factor
+from celldetective.utils.image_transforms import _combined_scale_factor
 from celldetective.utils.mask_cleaning import _check_label_dims
 from celldetective.utils.mask_transforms import _rescale_labels
 from celldetective.utils.model_loaders import (
@@ -375,16 +375,16 @@ class SegmentCellDLProcess(BaseSegmentProcess):
     def detect_rescaling(self):
         """Detect the rescheduling factor for the images."""
 
-        self.scale = _estimate_scale_factor(
-            self.spatial_calibration, self.required_spatial_calibration
+        # One factor from both corrections. Estimating the calibration ratio
+        # on its own first and multiplying afterwards dropped it whenever it sat
+        # within 5% of 1 -- the "not worth resampling" shortcut, which stops
+        # being true once a cell-size correction is resampling the frame anyway.
+        self.scale = _combined_scale_factor(
+            self.spatial_calibration,
+            self.required_spatial_calibration,
+            self.cell_size,
+            self.target_cell_size,
         )
-        logger.info(f"Scale: {self.scale} [None = 1]...")
-
-        if self.target_cell_size is not None and self.scale is not None:
-            self.scale *= self.cell_size / self.target_cell_size
-        elif self.target_cell_size is not None:
-            if self.target_cell_size != self.cell_size:
-                self.scale = self.cell_size / self.target_cell_size
 
         logger.info(
             f"Scale accounting for expected cell size: {self.scale} [None = 1]..."

--- a/celldetective/processes/segment_cells.py
+++ b/celldetective/processes/segment_cells.py
@@ -303,8 +303,20 @@ class SegmentCellDLProcess(BaseSegmentProcess):
         # `segment()` and the single-frame panel applied it.
         self.target_cell_size = None
         self.cell_size = trained_cell_size_um(self.input_config)
-        if "target_cell_size_um" in self.input_config and self.cell_size is not None:
-            self.target_cell_size = self.input_config["target_cell_size_um"]
+        if self.cell_size is not None:
+            target = self.input_config.get("target_cell_size_um")
+            if target is not None and target <= 0:
+                # `segment()` rejects the same value outright, and the dialog no
+                # longer writes one, so this only catches a configuration saved by
+                # an earlier build. Dividing by it was the worse option: zero
+                # raised ZeroDivisionError once the run started, and a negative
+                # flipped the scale and segmented a mirrored frame.
+                logger.warning(
+                    f"Ignoring target_cell_size_um={target}: it must be strictly "
+                    "positive. Rescaling on spatial calibration alone."
+                )
+            else:
+                self.target_cell_size = target
 
         self.normalize_kwargs = _get_normalize_kwargs_from_config(self.input_config)
 

--- a/celldetective/processes/segment_cells.py
+++ b/celldetective/processes/segment_cells.py
@@ -26,7 +26,10 @@ from celldetective.utils.image_loaders import (
 from celldetective.utils.image_transforms import _estimate_scale_factor
 from celldetective.utils.mask_cleaning import _check_label_dims
 from celldetective.utils.mask_transforms import _rescale_labels
-from celldetective.utils.model_loaders import locate_segmentation_model
+from celldetective.utils.model_loaders import (
+    locate_segmentation_model,
+    trained_cell_size_um,
+)
 from celldetective.utils.parsing import (
     config_section_to_dict,
     _extract_nbr_channels_from_config,
@@ -292,13 +295,16 @@ class SegmentCellDLProcess(BaseSegmentProcess):
         if "selected_channels" in self.input_config:
             self.required_channels = self.input_config["selected_channels"]
 
+        # Through the same helper the library and the napari panel use, so a
+        # cell size set in the main window means the same thing everywhere. A
+        # generalist Cellpose model states its trained size in pixels rather
+        # than as `cell_size_um`; gating on that key alone made the model
+        # parameter dialog offer a cell size that this run then ignored, while
+        # `segment()` and the single-frame panel applied it.
         self.target_cell_size = None
-        if (
-            "target_cell_size_um" in self.input_config
-            and "cell_size_um" in self.input_config
-        ):
+        self.cell_size = trained_cell_size_um(self.input_config)
+        if "target_cell_size_um" in self.input_config and self.cell_size is not None:
             self.target_cell_size = self.input_config["target_cell_size_um"]
-            self.cell_size = self.input_config["cell_size_um"]
 
         self.normalize_kwargs = _get_normalize_kwargs_from_config(self.input_config)
 

--- a/celldetective/regionprops/_regionprops.py
+++ b/celldetective/regionprops/_regionprops.py
@@ -112,6 +112,16 @@ class CustomRegionProps(RegionProperties):
             self.channel_names = list(self.channel_names)
         super().__init__(*args, **kwargs)
 
+        # Pre-compute channel name to index mapping for O(1) lookups
+        self._channel_name_to_idx = (
+            {name: idx for idx, name in enumerate(self.channel_names)}
+            if self.channel_names is not None
+            else None
+        )
+        
+        # Cache signature information for extra properties
+        self._signature_cache = {}
+
     def __getattr__(self, attr: str) -> Any:
         """
         Get attribute.
@@ -127,6 +137,10 @@ class CustomRegionProps(RegionProperties):
             Attribute value.
         """
 
+        # Checked here rather than in __init__: a mismatched `channel_names` is
+        # only a problem for the extra properties that actually consume it, and
+        # measuring standard properties (area, centroid, ...) with a channel
+        # subset has always been allowed.
         if self.channel_names is not None and self._multichannel:
             if len(self.channel_names) != self._intensity_image.shape[-1]:
                 raise ValueError("Mismatch between provided channel names and the number of channels in the image...")
@@ -146,24 +160,27 @@ class CustomRegionProps(RegionProperties):
             if n_args == 2:
                 if self._intensity_image is not None:
                     if self._multichannel:
-                        arg_dict = dict(inspect.signature(func).parameters)
+                        # Cache signature inspection for performance
+                        if func not in self._signature_cache:
+                            self._signature_cache[func] = dict(inspect.signature(func).parameters)
+                        arg_dict = self._signature_cache[func]
+                        
                         if (
-                            self.channel_names is not None
+                            self._channel_name_to_idx is not None
                             and "target_channel" in arg_dict
                         ):
                             # Channel-specific function: read the DEFAULT value of
                             # `target_channel` via inspect.signature to find which
                             # channel to run on.  The function is called once for
                             # that channel only; all other slots stay NaN.
-                            multichannel_list = [
-                                np.nan for i in range(self.image_intensity.shape[-1])
-                            ]
+                            n_channels = self._intensity_image.shape[-1]
+                            multichannel_list = [np.nan for i in range(n_channels)]
                             len_output = 1
                             default_channel = arg_dict["target_channel"]._default
 
-                            if default_channel in self.channel_names:
-
-                                idx = self.channel_names.index(default_channel)
+                            # O(1) lookup instead of O(n) list.index()
+                            idx = self._channel_name_to_idx.get(default_channel, -1)
+                            if idx >= 0:
                                 res = func(self.image, self.image_intensity[..., idx])
                                 if isinstance(res, tuple):
                                     len_output = len(res)
@@ -173,13 +190,11 @@ class CustomRegionProps(RegionProperties):
                                 if len_output > 1:
                                     multichannel_list = [
                                         [np.nan] * len_output
-                                        for c in range(len(self.channel_names))
+                                        for c in range(n_channels)
                                     ]
                                     multichannel_list[idx] = res
                                 else:
-                                    multichannel_list = [
-                                        np.nan for c in range(len(self.channel_names))
-                                    ]
+                                    multichannel_list = [np.nan for c in range(n_channels)]
                                     multichannel_list[idx] = res
 
                             else:
@@ -191,7 +206,7 @@ class CustomRegionProps(RegionProperties):
                         else:
                             multichannel_list = [
                                 func(self.image, self.image_intensity[..., i])
-                                for i in range(self.image_intensity.shape[-1])
+                                for i in range(self._intensity_image.shape[-1])
                             ]
                             return np.stack(multichannel_list, axis=-1)
                     else:

--- a/celldetective/segmentation.py
+++ b/celldetective/segmentation.py
@@ -309,8 +309,12 @@ def prepare_segmentation_model(
             model_name, Path(model_path).parent, use_gpu=use_gpu, scale=scale
         )
     elif model_type == "cellpose":
+        # `model_name` directly, as SegmentCellDLProcess does. Deriving it from
+        # the path as `model_path.split("/")[-2]` raised IndexError on Windows,
+        # where locate_segmentation_model returns os.sep-joined backslashes and
+        # the split yields a single element.
         model, scale_model = _prep_cellpose_model(
-            model_path.split("/")[-2],
+            model_name,
             model_path,
             use_gpu=use_gpu,
             n_channels=len(required_channels),

--- a/celldetective/segmentation.py
+++ b/celldetective/segmentation.py
@@ -26,6 +26,7 @@ Segmentation parameters are typically passed via a dictionary or configuration o
 import json
 import os
 import numpy as np
+from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from celldetective.utils.model_loaders import locate_segmentation_model
@@ -104,8 +105,13 @@ class PreparedSegmentationModel:
             Channel names of the images that will be passed to :func:`segment_frame`.
     required_channels : list of str
             Channel names the model expects, in the order it expects them.
+    channel_indices : list of int or None
+            One entry per model input slot: the index into `channels` of the image
+            channel feeding it, or None when the slot has no source. Matching is
+            case-insensitive, and the same image channel may feed several slots.
+            This is what :func:`segment_frame` transfers with.
     channel_intersection : list of str
-            Channels present in both of the above - the ones actually transferred.
+            The channel names actually transferred, one per filled slot.
     none_channel_indices : numpy.ndarray
             Indices of required channels missing from the image; zeroed before inference.
     normalize_kwargs : dict
@@ -116,6 +122,10 @@ class PreparedSegmentationModel:
             Cellpose cell probability threshold. None for StarDist models.
     flow_threshold : float or None
             Cellpose flow threshold. None for StarDist models.
+    config_defaults : dict
+            The inference parameters as the model configuration declares them, before
+            any caller override. Lets a caller restore a model's own values without
+            re-reading ``config_input.json``.
     """
 
     __slots__ = (
@@ -124,12 +134,14 @@ class PreparedSegmentationModel:
         "scale_model",
         "channels",
         "required_channels",
+        "channel_indices",
         "channel_intersection",
         "none_channel_indices",
         "normalize_kwargs",
         "diameter",
         "cellprob_threshold",
         "flow_threshold",
+        "config_defaults",
     )
 
     def __init__(
@@ -139,24 +151,57 @@ class PreparedSegmentationModel:
         scale_model: Optional[float],
         channels: List[str],
         required_channels: List[str],
+        channel_indices: List[Optional[int]],
         channel_intersection: List[str],
         none_channel_indices: np.ndarray,
         normalize_kwargs: Dict[str, Any],
         diameter: Optional[float] = None,
         cellprob_threshold: Optional[float] = None,
         flow_threshold: Optional[float] = None,
+        config_defaults: Optional[Dict[str, Any]] = None,
     ) -> None:
         self.model = model
         self.model_type = model_type
         self.scale_model = scale_model
         self.channels = channels
         self.required_channels = required_channels
+        self.channel_indices = channel_indices
         self.channel_intersection = channel_intersection
         self.none_channel_indices = none_channel_indices
         self.normalize_kwargs = normalize_kwargs
         self.diameter = diameter
         self.cellprob_threshold = cellprob_threshold
         self.flow_threshold = flow_threshold
+        self.config_defaults = config_defaults if config_defaults is not None else {}
+
+
+@contextmanager
+def _gpu_visibility(use_gpu: bool):
+    """
+    Expose or hide the GPU to the DL frameworks, then put the environment back.
+
+    ``CUDA_VISIBLE_DEVICES`` is process-global, and both TensorFlow and Torch read
+    it once, when they first initialise a device context. Leaving it set - as this
+    module used to - meant that a single CPU-only call from the GUI silently pinned
+    the whole process to the CPU for good. Setting it only around model
+    construction gets the intended device and leaves the caller's environment
+    exactly as it was found.
+
+    Parameters
+    ----------
+    use_gpu : bool
+            Whether the GPU should be visible while the model is built.
+    """
+
+    previous = os.environ.get("CUDA_VISIBLE_DEVICES")
+    os.environ["CUDA_VISIBLE_DEVICES"] = "0" if use_gpu else "-1"
+    try:
+        yield
+    finally:
+        if previous is None:
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        else:
+            os.environ["CUDA_VISIBLE_DEVICES"] = previous
 
 
 def prepare_segmentation_model(
@@ -239,11 +284,6 @@ def prepare_segmentation_model(
         logger.error("Model input configuration could not be located...")
         return None
 
-    if not use_gpu:
-        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
-    else:
-        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
-
     # The channel-selection dialog stores the experiment channel feeding each of
     # the model's input slots as `selected_channels`, same length and order as
     # `channels`. Honour it exactly as SegmentCellDLProcess does, so calling this
@@ -261,24 +301,39 @@ def prepare_segmentation_model(
     else:
         channels = list(channels)
 
-    channel_intersection = [ch for ch in channels if ch in required_channels]
+    # One entry per model input slot: the index into `channels` of the image
+    # channel feeding it, or None. Resolving per slot rather than intersecting the
+    # two name lists means the same image channel can feed several slots - which
+    # the channel-selection dialog allows and the pipeline handles, since
+    # `_get_img_num_per_channel` gives every slot its own row - and it keeps the
+    # case-insensitive matching of `_extract_channel_indices` instead of pairing
+    # it with a case-sensitive membership test.
+    channel_indices = _extract_channel_indices(channels, required_channels)
+    channel_intersection = [channels[i] for i in channel_indices if i is not None]
     if len(channel_intersection) == 0:
         raise ValueError("None of the channels required by the model can be found in the images to segment... Abort.")
-
-    channel_indices = _extract_channel_indices(channels, required_channels)
 
     required_spatial_calibration = input_config["spatial_calibration"]
     model_type = input_config["model_type"]
 
     normalize_kwargs = _get_normalize_kwargs_from_config(input_config)
 
+    # Kept alongside the resolved values so a caller can go back to the model's
+    # own settings without re-reading the configuration from disk.
+    config_defaults: Dict[str, Any] = {}
+
     if model_type == "cellpose":
+        config_defaults = {
+            "diameter": input_config["diameter"],
+            "cellprob_threshold": input_config["cellprob_threshold"],
+            "flow_threshold": input_config["flow_threshold"],
+        }
         if diameter is None:
-            diameter = input_config["diameter"]
+            diameter = config_defaults["diameter"]
         if cellprob_threshold is None:
-            cellprob_threshold = input_config["cellprob_threshold"]
+            cellprob_threshold = config_defaults["cellprob_threshold"]
         if flow_threshold is None:
-            flow_threshold = input_config["flow_threshold"]
+            flow_threshold = config_defaults["flow_threshold"]
     else:
         diameter = None
 
@@ -304,22 +359,23 @@ def prepare_segmentation_model(
 
     model = None
     scale_model = None
-    if model_type == "stardist":
-        model, scale_model = _prep_stardist_model(
-            model_name, Path(model_path).parent, use_gpu=use_gpu, scale=scale
-        )
-    elif model_type == "cellpose":
-        # `model_name` directly, as SegmentCellDLProcess does. Deriving it from
-        # the path as `model_path.split("/")[-2]` raised IndexError on Windows,
-        # where locate_segmentation_model returns os.sep-joined backslashes and
-        # the split yields a single element.
-        model, scale_model = _prep_cellpose_model(
-            model_name,
-            model_path,
-            use_gpu=use_gpu,
-            n_channels=len(required_channels),
-            scale=scale,
-        )
+    with _gpu_visibility(use_gpu):
+        if model_type == "stardist":
+            model, scale_model = _prep_stardist_model(
+                model_name, Path(model_path).parent, use_gpu=use_gpu, scale=scale
+            )
+        elif model_type == "cellpose":
+            # `model_name` directly, as SegmentCellDLProcess does. Deriving it from
+            # the path as `model_path.split("/")[-2]` raised IndexError on Windows,
+            # where locate_segmentation_model returns os.sep-joined backslashes and
+            # the split yields a single element.
+            model, scale_model = _prep_cellpose_model(
+                model_name,
+                model_path,
+                use_gpu=use_gpu,
+                n_channels=len(required_channels),
+                scale=scale,
+            )
 
     if model is None:
         logger.error(f"Could not load model {model_name}. Aborting segmentation.")
@@ -336,12 +392,14 @@ def prepare_segmentation_model(
         scale_model=scale_model,
         channels=channels,
         required_channels=required_channels,
+        channel_indices=channel_indices,
         channel_intersection=channel_intersection,
         none_channel_indices=none_channel_indices,
         normalize_kwargs=normalize_kwargs,
         diameter=diameter,
         cellprob_threshold=cellprob_threshold,
         flow_threshold=flow_threshold,
+        config_defaults=config_defaults,
     )
 
 
@@ -377,17 +435,19 @@ def segment_frame(
 
     """
 
-    channels = prepared.channels
     required_channels = prepared.required_channels
 
     frame = _rearrange_multichannel_frame(frame).astype(float)
 
+    # Walk the slots, not the matched names: a name lookup collapses a mapping
+    # that feeds one image channel into several slots down to the first of them,
+    # leaving the rest silently black.
     frame_to_segment = np.zeros(
         (frame.shape[0], frame.shape[1], len(required_channels))
     ).astype(float)
-    for ch in prepared.channel_intersection:
-        idx = required_channels.index(ch)
-        frame_to_segment[:, :, idx] = frame[:, :, channels.index(ch)]
+    for slot, source in enumerate(prepared.channel_indices):
+        if source is not None:
+            frame_to_segment[:, :, slot] = frame[:, :, source]
     frame = frame_to_segment
     template = frame.copy()
 
@@ -433,7 +493,10 @@ def segment(
     channel_axis: int = -1,
     cellprob_threshold: Optional[float] = None,
     flow_threshold: Optional[float] = None,
-) -> np.ndarray:
+    selected_channels: Optional[List[str]] = None,
+    target_cell_size: Optional[float] = None,
+    diameter: Optional[float] = None,
+) -> Optional[np.ndarray]:
     """
 
     Segment objects in a stack using a pre-trained segmentation model.
@@ -460,17 +523,51 @@ def segment(
                 Cell probability threshold for Cellpose mask computation. Default is None.
     flow_threshold : float, optional
                 Flow threshold for Cellpose mask computation. Default is None.
+    selected_channels : list or None, optional
+            The experiment channels feeding the model's input slots, one per slot, in
+            the model's own order; ``"None"`` leaves a slot blank. Overrides the
+            ``selected_channels`` mapping stored in the model configuration. Pass the
+            model's own ``channels`` list to ignore the stored mapping entirely.
+            Default is None (use the stored mapping).
+    target_cell_size : float or None, optional
+            Typical object size in the images, in µm, used together with the model's
+            ``cell_size_um`` to rescale the images. Overrides the stored
+            ``target_cell_size_um``. Default is None (use the stored value).
+    diameter : float or None, optional
+            Cellpose object diameter, in pixels, overriding the model configuration.
+            Ignored for StarDist models. Default is None.
 
     Returns
     -------
-    ndarray
-            The segmented labels with shape (frames, height, width).
+    ndarray or None
+            The segmented labels with shape (frames, height, width), or None if the
+            model or its input configuration could not be located.
 
     Notes
     -----
     This function applies object segmentation to a stack of images using a pre-trained segmentation model. The stack is first
     preprocessed by normalizing the intensity values, rescaling the spatial dimensions, and applying the segmentation model.
     The resulting labels are returned as an ndarray with the same number of frames as the input stack.
+
+    This is a thin wrapper over :func:`prepare_segmentation_model` (called once) and
+    :func:`segment_frame` (called per frame). Reach for those two directly when the
+    same model has to run on frames that do not arrive as one stack.
+
+    .. versionchanged:: 1.5.4
+            Two settings that ``SegmentCellDLProcess`` had always applied, and that
+            this function had always ignored, are now honoured here too, so the
+            library and the pipeline return the same masks for the same model:
+
+            - the ``selected_channels`` mapping stored in the model's
+              ``config_input.json`` by the channel-selection dialog, which now takes
+              precedence over the model's own ``channels`` list;
+            - the ``cell_size_um`` / ``target_cell_size_um`` rescaling.
+
+            Both come from the model directory, which is shared across experiments, so
+            a mapping saved while working on one experiment now also applies to direct
+            ``segment()`` calls made for another. Pass `selected_channels` and
+            `target_cell_size` explicitly to pin the behaviour and ignore what is
+            stored.
 
     Examples
     --------
@@ -493,6 +590,9 @@ def segment(
         use_gpu=use_gpu,
         cellprob_threshold=cellprob_threshold,
         flow_threshold=flow_threshold,
+        selected_channels=selected_channels,
+        target_cell_size=target_cell_size,
+        diameter=diameter,
     )
     if prepared is None:
         return None

--- a/celldetective/segmentation.py
+++ b/celldetective/segmentation.py
@@ -126,6 +126,11 @@ class PreparedSegmentationModel:
             The inference parameters as the model configuration declares them, before
             any caller override. Lets a caller restore a model's own values without
             re-reading ``config_input.json``.
+    use_gpu : bool
+            The device choice this model was built under. :func:`segment_frame`
+            re-applies it around inference, since a framework that defers creating
+            its device context until the first prediction would otherwise see the
+            caller's environment rather than this one.
     """
 
     __slots__ = (
@@ -142,6 +147,7 @@ class PreparedSegmentationModel:
         "cellprob_threshold",
         "flow_threshold",
         "config_defaults",
+        "use_gpu",
     )
 
     def __init__(
@@ -159,6 +165,7 @@ class PreparedSegmentationModel:
         cellprob_threshold: Optional[float] = None,
         flow_threshold: Optional[float] = None,
         config_defaults: Optional[Dict[str, Any]] = None,
+        use_gpu: bool = True,
     ) -> None:
         self.model = model
         self.model_type = model_type
@@ -173,6 +180,7 @@ class PreparedSegmentationModel:
         self.cellprob_threshold = cellprob_threshold
         self.flow_threshold = flow_threshold
         self.config_defaults = config_defaults if config_defaults is not None else {}
+        self.use_gpu = use_gpu
 
 
 @contextmanager
@@ -183,14 +191,15 @@ def _gpu_visibility(use_gpu: bool):
     ``CUDA_VISIBLE_DEVICES`` is process-global, and both TensorFlow and Torch read
     it once, when they first initialise a device context. Leaving it set - as this
     module used to - meant that a single CPU-only call from the GUI silently pinned
-    the whole process to the CPU for good. Setting it only around model
-    construction gets the intended device and leaves the caller's environment
-    exactly as it was found.
+    the whole process to the CPU for good. Entering this context around both model
+    construction and inference gets the intended device wherever that context
+    happens to be created, and leaves the caller's environment exactly as it was
+    found.
 
     Parameters
     ----------
     use_gpu : bool
-            Whether the GPU should be visible while the model is built.
+            Whether the GPU should be visible inside the block.
     """
 
     previous = os.environ.get("CUDA_VISIBLE_DEVICES")
@@ -214,6 +223,7 @@ def prepare_segmentation_model(
     selected_channels: Optional[List[str]] = None,
     target_cell_size: Optional[float] = None,
     diameter: Optional[float] = None,
+    use_stored_mapping: bool = False,
 ) -> Optional[PreparedSegmentationModel]:
     """
 
@@ -251,6 +261,14 @@ def prepare_segmentation_model(
     diameter : float or None, optional
             Cellpose object diameter, in pixels. Overrides the value stored in the
             model configuration. Ignored for StarDist models. Default is None.
+    use_stored_mapping : bool, optional
+            Whether to fall back on the ``selected_channels`` and
+            ``target_cell_size_um`` entries that the channel-selection dialog writes
+            into the model's ``config_input.json``. That file lives in the installed
+            package, shared by every experiment, so honouring it silently would let a
+            mapping saved in the GUI change what this function returns for an
+            unrelated call. The GUI opts in to get pipeline parity; library callers
+            get the model's own channel list unless they ask. Default is False.
 
     Returns
     -------
@@ -291,7 +309,7 @@ def prepare_segmentation_model(
     required_channels = input_config["channels"]
     if selected_channels is not None:
         required_channels = list(selected_channels)
-    elif "selected_channels" in input_config:
+    elif use_stored_mapping and "selected_channels" in input_config:
         required_channels = input_config["selected_channels"]
 
     # The docstring has always allowed channels=None; without this the channel
@@ -323,10 +341,13 @@ def prepare_segmentation_model(
     config_defaults: Dict[str, Any] = {}
 
     if model_type == "cellpose":
+        # `.get`, not indexing: a hand-written or older configuration may omit
+        # these, and a caller that passes them explicitly should not be stopped by
+        # a default it never uses.
         config_defaults = {
-            "diameter": input_config["diameter"],
-            "cellprob_threshold": input_config["cellprob_threshold"],
-            "flow_threshold": input_config["flow_threshold"],
+            "diameter": input_config.get("diameter"),
+            "cellprob_threshold": input_config.get("cellprob_threshold"),
+            "flow_threshold": input_config.get("flow_threshold"),
         }
         if diameter is None:
             diameter = config_defaults["diameter"]
@@ -344,8 +365,19 @@ def prepare_segmentation_model(
     # `cell_size_um` is what the model saw, `target_cell_size_um` what these
     # images hold.
     cell_size = input_config.get("cell_size_um")
-    if target_cell_size is None:
+    if target_cell_size is None and use_stored_mapping:
         target_cell_size = input_config.get("target_cell_size_um")
+    if target_cell_size is not None and target_cell_size <= 0:
+        raise ValueError(
+            f"The target cell size must be strictly positive, got {target_cell_size}."
+        )
+    if cell_size is not None and cell_size <= 0:
+        # Comes from the model configuration, not the caller: warn and fall back on
+        # the calibration ratio alone rather than scaling everything to nothing.
+        logger.warning(
+            f"Ignoring the model's cell_size_um={cell_size}: it must be strictly positive."
+        )
+        cell_size = None
     if target_cell_size is not None and cell_size is not None:
         if scale is not None:
             scale *= cell_size / target_cell_size
@@ -400,6 +432,7 @@ def prepare_segmentation_model(
         cellprob_threshold=cellprob_threshold,
         flow_threshold=flow_threshold,
         config_defaults=config_defaults,
+        use_gpu=use_gpu,
     )
 
 
@@ -460,20 +493,25 @@ def segment_frame(
     frame = interpolate_nan_multichannel(frame)
     frame[:, :, prepared.none_channel_indices] = 0.0
 
-    if prepared.model_type == "stardist":
-        Y_pred = _segment_image_with_stardist_model(
-            frame, model=prepared.model, return_details=False
-        )
-    elif prepared.model_type == "cellpose":
-        Y_pred = _segment_image_with_cellpose_model(
-            frame,
-            model=prepared.model,
-            diameter=prepared.diameter,
-            cellprob_threshold=prepared.cellprob_threshold,
-            flow_threshold=prepared.flow_threshold,
-        )
-    else:
-        raise ValueError(f"Unknown model type {prepared.model_type}...")
+    # Same device visibility as when the model was built: TensorFlow reads
+    # CUDA_VISIBLE_DEVICES when it creates its device context, and whether that
+    # happens in the StarDist constructor or on the first `predict` is an
+    # implementation detail we should not be relying on.
+    with _gpu_visibility(prepared.use_gpu):
+        if prepared.model_type == "stardist":
+            Y_pred = _segment_image_with_stardist_model(
+                frame, model=prepared.model, return_details=False
+            )
+        elif prepared.model_type == "cellpose":
+            Y_pred = _segment_image_with_cellpose_model(
+                frame,
+                model=prepared.model,
+                diameter=prepared.diameter,
+                cellprob_threshold=prepared.cellprob_threshold,
+                flow_threshold=prepared.flow_threshold,
+            )
+        else:
+            raise ValueError(f"Unknown model type {prepared.model_type}...")
 
     # `template` carries this frame's pre-rescaling dimensions, so the check is
     # made per frame rather than assuming every frame matches the first.
@@ -496,6 +534,7 @@ def segment(
     selected_channels: Optional[List[str]] = None,
     target_cell_size: Optional[float] = None,
     diameter: Optional[float] = None,
+    use_stored_mapping: bool = False,
 ) -> Optional[np.ndarray]:
     """
 
@@ -536,6 +575,13 @@ def segment(
     diameter : float or None, optional
             Cellpose object diameter, in pixels, overriding the model configuration.
             Ignored for StarDist models. Default is None.
+    use_stored_mapping : bool, optional
+            Whether to fall back on the ``selected_channels`` and
+            ``target_cell_size_um`` entries stored in the model's
+            ``config_input.json`` by the channel-selection dialog. Set it to True to
+            reproduce exactly what the pipeline does for the same model; leave it
+            False to keep a call reproducible whatever was last set in the GUI.
+            Default is False.
 
     Returns
     -------
@@ -555,19 +601,21 @@ def segment(
 
     .. versionchanged:: 1.5.4
             Two settings that ``SegmentCellDLProcess`` had always applied, and that
-            this function had always ignored, are now honoured here too, so the
+            this function had always ignored, can now be honoured here too, so the
             library and the pipeline return the same masks for the same model:
 
             - the ``selected_channels`` mapping stored in the model's
-              ``config_input.json`` by the channel-selection dialog, which now takes
+              ``config_input.json`` by the channel-selection dialog, which then takes
               precedence over the model's own ``channels`` list;
             - the ``cell_size_um`` / ``target_cell_size_um`` rescaling.
 
-            Both come from the model directory, which is shared across experiments, so
-            a mapping saved while working on one experiment now also applies to direct
-            ``segment()`` calls made for another. Pass `selected_channels` and
-            `target_cell_size` explicitly to pin the behaviour and ignore what is
-            stored.
+            Both come from the model directory, which is installed once and shared by
+            every experiment, so applying them by default would let a mapping saved
+            while working on one experiment change what this function returns for
+            another. They are therefore opt-in: pass `use_stored_mapping=True` for
+            pipeline parity, or `selected_channels` / `target_cell_size` to set them
+            explicitly. Without either, the model's own ``channels`` list is used, as
+            before.
 
     Examples
     --------
@@ -593,6 +641,7 @@ def segment(
         selected_channels=selected_channels,
         target_cell_size=target_cell_size,
         diameter=diameter,
+        use_stored_mapping=use_stored_mapping,
     )
     if prepared is None:
         return None

--- a/celldetective/segmentation.py
+++ b/celldetective/segmentation.py
@@ -166,6 +166,9 @@ def prepare_segmentation_model(
     use_gpu: bool = True,
     cellprob_threshold: Optional[float] = None,
     flow_threshold: Optional[float] = None,
+    selected_channels: Optional[List[str]] = None,
+    target_cell_size: Optional[float] = None,
+    diameter: Optional[float] = None,
 ) -> Optional[PreparedSegmentationModel]:
     """
 
@@ -190,6 +193,19 @@ def prepare_segmentation_model(
             Cell probability threshold for Cellpose mask computation. Default is None.
     flow_threshold : float, optional
             Flow threshold for Cellpose mask computation. Default is None.
+    selected_channels : list or None, optional
+            The experiment channels feeding the model's input slots, one per slot,
+            in the model's own order; ``"None"`` leaves a slot blank. Overrides the
+            ``selected_channels`` mapping stored in the model configuration by the
+            channel-selection dialog. Default is None (use the stored mapping).
+    target_cell_size : float or None, optional
+            Typical object size in the images, in µm. Combined with the model's
+            ``cell_size_um`` it rescales the images so objects match the size the
+            model was trained on. Overrides the stored ``target_cell_size_um``.
+            Default is None (use the stored value).
+    diameter : float or None, optional
+            Cellpose object diameter, in pixels. Overrides the value stored in the
+            model configuration. Ignored for StarDist models. Default is None.
 
     Returns
     -------
@@ -228,7 +244,15 @@ def prepare_segmentation_model(
     else:
         os.environ["CUDA_VISIBLE_DEVICES"] = "0"
 
+    # The channel-selection dialog stores the experiment channel feeding each of
+    # the model's input slots as `selected_channels`, same length and order as
+    # `channels`. Honour it exactly as SegmentCellDLProcess does, so calling this
+    # function directly gives the same masks as running the pipeline.
     required_channels = input_config["channels"]
+    if selected_channels is not None:
+        required_channels = list(selected_channels)
+    elif "selected_channels" in input_config:
+        required_channels = input_config["selected_channels"]
 
     # The docstring has always allowed channels=None; without this the channel
     # intersection below raises a TypeError instead of falling back.
@@ -248,17 +272,34 @@ def prepare_segmentation_model(
 
     normalize_kwargs = _get_normalize_kwargs_from_config(input_config)
 
-    diameter = None
     if model_type == "cellpose":
-        diameter = input_config["diameter"]
+        if diameter is None:
+            diameter = input_config["diameter"]
         if cellprob_threshold is None:
             cellprob_threshold = input_config["cellprob_threshold"]
         if flow_threshold is None:
             flow_threshold = input_config["flow_threshold"]
+    else:
+        diameter = None
 
     scale = _estimate_scale_factor(spatial_calibration, required_spatial_calibration)
+
+    # Correct the scale so that objects come out the size the model was trained
+    # on, mirroring SegmentCellDLProcess.estimate_scale. Both sizes are needed:
+    # `cell_size_um` is what the model saw, `target_cell_size_um` what these
+    # images hold.
+    cell_size = input_config.get("cell_size_um")
+    if target_cell_size is None:
+        target_cell_size = input_config.get("target_cell_size_um")
+    if target_cell_size is not None and cell_size is not None:
+        if scale is not None:
+            scale *= cell_size / target_cell_size
+        elif target_cell_size != cell_size:
+            scale = cell_size / target_cell_size
+
     logger.info(
-        f"{spatial_calibration=} {required_spatial_calibration=} Scale = {scale}..."
+        f"{spatial_calibration=} {required_spatial_calibration=} "
+        f"{cell_size=} {target_cell_size=} Scale = {scale}..."
     )
 
     model = None

--- a/celldetective/segmentation.py
+++ b/celldetective/segmentation.py
@@ -255,12 +255,15 @@ def prepare_segmentation_model(
             The experiment channels feeding the model's input slots, one per slot,
             in the model's own order; ``"None"`` leaves a slot blank. Overrides the
             ``selected_channels`` mapping stored in the model configuration by the
-            channel-selection dialog. Default is None (use the stored mapping).
+            channel-selection dialog. Default is None: the stored mapping when
+            ``use_stored_mapping`` is set, the model's own ``channels`` list
+            otherwise.
     target_cell_size : float or None, optional
             Typical object size in the images, in µm. Combined with the model's
             ``cell_size_um`` it rescales the images so objects match the size the
             model was trained on. Overrides the stored ``target_cell_size_um``.
-            Default is None (use the stored value).
+            Default is None: the stored value when ``use_stored_mapping`` is set,
+            no cell-size rescaling otherwise.
     diameter : float or None, optional
             Cellpose object diameter, in pixels. Overrides the value stored in the
             model configuration. Ignored for StarDist models. Default is None.
@@ -577,11 +580,13 @@ def segment(
             the model's own order; ``"None"`` leaves a slot blank. Overrides the
             ``selected_channels`` mapping stored in the model configuration. Pass the
             model's own ``channels`` list to ignore the stored mapping entirely.
-            Default is None (use the stored mapping).
+            Default is None: the stored mapping when ``use_stored_mapping`` is set,
+            the model's own ``channels`` list otherwise.
     target_cell_size : float or None, optional
             Typical object size in the images, in µm, used together with the model's
             ``cell_size_um`` to rescale the images. Overrides the stored
-            ``target_cell_size_um``. Default is None (use the stored value).
+            ``target_cell_size_um``. Default is None: the stored value when
+            ``use_stored_mapping`` is set, no cell-size rescaling otherwise.
     diameter : float or None, optional
             Cellpose object diameter, in pixels, overriding the model configuration.
             Ignored for StarDist models. Default is None.

--- a/celldetective/segmentation.py
+++ b/celldetective/segmentation.py
@@ -29,7 +29,10 @@ import numpy as np
 from contextlib import contextmanager
 from typing import Any, Dict, List, Optional, Tuple, Union
 
-from celldetective.utils.model_loaders import locate_segmentation_model
+from celldetective.utils.model_loaders import (
+    locate_segmentation_model,
+    trained_cell_size_um,
+)
 from celldetective.utils.normalization import normalize_multichannel
 from pathlib import Path
 from tqdm import tqdm
@@ -364,20 +367,16 @@ def prepare_segmentation_model(
     # on, mirroring SegmentCellDLProcess.estimate_scale. Both sizes are needed:
     # `cell_size_um` is what the model saw, `target_cell_size_um` what these
     # images hold.
-    cell_size = input_config.get("cell_size_um")
+    # Read from the model configuration, never from a caller's override: the
+    # override says what to ask Cellpose for, not what the network was trained on.
+    cell_size = trained_cell_size_um(input_config)
+
     if target_cell_size is None and use_stored_mapping:
         target_cell_size = input_config.get("target_cell_size_um")
     if target_cell_size is not None and target_cell_size <= 0:
         raise ValueError(
             f"The target cell size must be strictly positive, got {target_cell_size}."
         )
-    if cell_size is not None and cell_size <= 0:
-        # Comes from the model configuration, not the caller: warn and fall back on
-        # the calibration ratio alone rather than scaling everything to nothing.
-        logger.warning(
-            f"Ignoring the model's cell_size_um={cell_size}: it must be strictly positive."
-        )
-        cell_size = None
     if target_cell_size is not None and cell_size is not None:
         if scale is not None:
             scale *= cell_size / target_cell_size
@@ -471,6 +470,17 @@ def segment_frame(
     required_channels = prepared.required_channels
 
     frame = _rearrange_multichannel_frame(frame).astype(float)
+
+    # Same contract as segment(): the frame's channels are the ones named in
+    # prepared.channels. Checked here too, because the mapping is resolved
+    # against those names and not against this frame -- without the check a
+    # too-narrow frame raises deep inside the channel transfer, and a wider one
+    # silently feeds arbitrary planes to the model.
+    if frame.shape[-1] != len(prepared.channels):
+        raise ValueError(
+            f"The frame has {frame.shape[-1]} channel(s) but the model was "
+            f"prepared for {len(prepared.channels)}: {prepared.channels}."
+        )
 
     # Walk the slots, not the matched names: a name lookup collapses a mapping
     # that feeds one image channel into several slots down to the first of them,

--- a/celldetective/segmentation.py
+++ b/celldetective/segmentation.py
@@ -80,6 +80,304 @@ abs_path = os.sep.join(
 )
 
 
+class PreparedSegmentationModel:
+    """
+    A segmentation model loaded and configured for a given set of image channels.
+
+    Built by :func:`prepare_segmentation_model` and consumed by
+    :func:`segment_frame`. Holding the loaded model and its resolved channel
+    mapping in one object means the expensive setup (reading
+    ``config_input.json``, estimating the rescaling factor, instantiating the
+    StarDist / Cellpose model) happens once and can then be reused across as many
+    frames as needed - a whole stack, or a single frame picked in napari.
+
+    Attributes
+    ----------
+    model : object
+            The instantiated StarDist or Cellpose model.
+    model_type : str
+            Either ``"stardist"`` or ``"cellpose"``.
+    scale_model : float or None
+            Zoom factor applied to a frame before inference, or None when the
+            image calibration already matches the model's.
+    channels : list of str
+            Channel names of the images that will be passed to :func:`segment_frame`.
+    required_channels : list of str
+            Channel names the model expects, in the order it expects them.
+    channel_intersection : list of str
+            Channels present in both of the above - the ones actually transferred.
+    none_channel_indices : numpy.ndarray
+            Indices of required channels missing from the image; zeroed before inference.
+    normalize_kwargs : dict
+            Normalization settings read from the model configuration.
+    diameter : float or None
+            Cellpose object diameter. None for StarDist models.
+    cellprob_threshold : float or None
+            Cellpose cell probability threshold. None for StarDist models.
+    flow_threshold : float or None
+            Cellpose flow threshold. None for StarDist models.
+    """
+
+    __slots__ = (
+        "model",
+        "model_type",
+        "scale_model",
+        "channels",
+        "required_channels",
+        "channel_intersection",
+        "none_channel_indices",
+        "normalize_kwargs",
+        "diameter",
+        "cellprob_threshold",
+        "flow_threshold",
+    )
+
+    def __init__(
+        self,
+        model: Any,
+        model_type: str,
+        scale_model: Optional[float],
+        channels: List[str],
+        required_channels: List[str],
+        channel_intersection: List[str],
+        none_channel_indices: np.ndarray,
+        normalize_kwargs: Dict[str, Any],
+        diameter: Optional[float] = None,
+        cellprob_threshold: Optional[float] = None,
+        flow_threshold: Optional[float] = None,
+    ) -> None:
+        self.model = model
+        self.model_type = model_type
+        self.scale_model = scale_model
+        self.channels = channels
+        self.required_channels = required_channels
+        self.channel_intersection = channel_intersection
+        self.none_channel_indices = none_channel_indices
+        self.normalize_kwargs = normalize_kwargs
+        self.diameter = diameter
+        self.cellprob_threshold = cellprob_threshold
+        self.flow_threshold = flow_threshold
+
+
+def prepare_segmentation_model(
+    model_name: str,
+    channels: Optional[List[str]] = None,
+    spatial_calibration: Optional[float] = None,
+    use_gpu: bool = True,
+    cellprob_threshold: Optional[float] = None,
+    flow_threshold: Optional[float] = None,
+) -> Optional[PreparedSegmentationModel]:
+    """
+
+    Load a segmentation model and resolve it against a set of image channels.
+
+    This is the setup half of :func:`segment`, split out so that the loaded model
+    can be reused frame by frame instead of being rebuilt on every call.
+
+    Parameters
+    ----------
+    model_name : str
+            The name of the pre-trained segmentation model to use.
+    channels : list or None, optional
+            The names of the channels in the images to segment. When None, the
+            model's own required channels are assumed, in order. Default is None.
+    spatial_calibration : float or None, optional
+            The spatial calibration factor of the images. If None, the calibration
+            factor from the model configuration will be used. Default is None.
+    use_gpu : bool, optional
+            Whether to use GPU acceleration if available. Default is True.
+    cellprob_threshold : float, optional
+            Cell probability threshold for Cellpose mask computation. Default is None.
+    flow_threshold : float, optional
+            Flow threshold for Cellpose mask computation. Default is None.
+
+    Returns
+    -------
+    PreparedSegmentationModel or None
+            The prepared model, or None if the model or its input configuration
+            could not be located.
+
+    Raises
+    ------
+    ValueError
+            If none of the channels required by the model are present in `channels`.
+
+    Examples
+    --------
+    >>> prepared = prepare_segmentation_model('model_name', channels=['brightfield_channel'])
+    >>> labels = segment_frame(frame, prepared)
+
+    """
+
+    model_path = locate_segmentation_model(model_name)
+    if model_path is None:
+        logger.error(f"Could not locate model {model_name}. Aborting segmentation.")
+        return None
+
+    input_config = model_path + "config_input.json"
+    if os.path.exists(input_config):
+        with open(input_config) as config:
+            logger.info("Loading input configuration from 'config_input.json'.")
+            input_config = json.load(config)
+    else:
+        logger.error("Model input configuration could not be located...")
+        return None
+
+    if not use_gpu:
+        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
+    else:
+        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
+
+    required_channels = input_config["channels"]
+
+    # The docstring has always allowed channels=None; without this the channel
+    # intersection below raises a TypeError instead of falling back.
+    if channels is None:
+        channels = list(required_channels)
+    else:
+        channels = list(channels)
+
+    channel_intersection = [ch for ch in channels if ch in required_channels]
+    if len(channel_intersection) == 0:
+        raise ValueError("None of the channels required by the model can be found in the images to segment... Abort.")
+
+    channel_indices = _extract_channel_indices(channels, required_channels)
+
+    required_spatial_calibration = input_config["spatial_calibration"]
+    model_type = input_config["model_type"]
+
+    normalize_kwargs = _get_normalize_kwargs_from_config(input_config)
+
+    diameter = None
+    if model_type == "cellpose":
+        diameter = input_config["diameter"]
+        if cellprob_threshold is None:
+            cellprob_threshold = input_config["cellprob_threshold"]
+        if flow_threshold is None:
+            flow_threshold = input_config["flow_threshold"]
+
+    scale = _estimate_scale_factor(spatial_calibration, required_spatial_calibration)
+    logger.info(
+        f"{spatial_calibration=} {required_spatial_calibration=} Scale = {scale}..."
+    )
+
+    model = None
+    scale_model = None
+    if model_type == "stardist":
+        model, scale_model = _prep_stardist_model(
+            model_name, Path(model_path).parent, use_gpu=use_gpu, scale=scale
+        )
+    elif model_type == "cellpose":
+        model, scale_model = _prep_cellpose_model(
+            model_path.split("/")[-2],
+            model_path,
+            use_gpu=use_gpu,
+            n_channels=len(required_channels),
+            scale=scale,
+        )
+
+    if model is None:
+        logger.error(f"Could not load model {model_name}. Aborting segmentation.")
+        return None
+
+    # Resolve the missing required channels once, rather than on every frame.
+    none_channel_indices = np.array(
+        [i for i, v in enumerate(channel_indices) if v is None], dtype=int
+    )
+
+    return PreparedSegmentationModel(
+        model=model,
+        model_type=model_type,
+        scale_model=scale_model,
+        channels=channels,
+        required_channels=required_channels,
+        channel_intersection=channel_intersection,
+        none_channel_indices=none_channel_indices,
+        normalize_kwargs=normalize_kwargs,
+        diameter=diameter,
+        cellprob_threshold=cellprob_threshold,
+        flow_threshold=flow_threshold,
+    )
+
+
+def segment_frame(
+    frame: np.ndarray,
+    prepared: PreparedSegmentationModel,
+) -> np.ndarray:
+    """
+
+    Segment a single frame with an already-prepared model.
+
+    This is the per-frame half of :func:`segment`. It performs the channel
+    transfer, normalization, rescaling and inference for one image, then rescales
+    the resulting labels back to that frame's original dimensions.
+
+    Parameters
+    ----------
+    frame : ndarray
+            A single multichannel image, with shape (height, width, channels) -
+            the channels being those named in ``prepared.channels``.
+    prepared : PreparedSegmentationModel
+            A model prepared by :func:`prepare_segmentation_model`.
+
+    Returns
+    -------
+    ndarray
+            The segmented labels, with shape (height, width).
+
+    Examples
+    --------
+    >>> prepared = prepare_segmentation_model('model_name', channels=['brightfield_channel'])
+    >>> labels = segment_frame(stack[0], prepared)
+
+    """
+
+    channels = prepared.channels
+    required_channels = prepared.required_channels
+
+    frame = _rearrange_multichannel_frame(frame).astype(float)
+
+    frame_to_segment = np.zeros(
+        (frame.shape[0], frame.shape[1], len(required_channels))
+    ).astype(float)
+    for ch in prepared.channel_intersection:
+        idx = required_channels.index(ch)
+        frame_to_segment[:, :, idx] = frame[:, :, channels.index(ch)]
+    frame = frame_to_segment
+    template = frame.copy()
+
+    frame = normalize_multichannel(frame, **prepared.normalize_kwargs)
+
+    if prepared.scale_model is not None:
+        frame = zoom_multiframes(frame, prepared.scale_model)
+
+    frame = _fix_no_contrast(frame)
+    frame = interpolate_nan_multichannel(frame)
+    frame[:, :, prepared.none_channel_indices] = 0.0
+
+    if prepared.model_type == "stardist":
+        Y_pred = _segment_image_with_stardist_model(
+            frame, model=prepared.model, return_details=False
+        )
+    elif prepared.model_type == "cellpose":
+        Y_pred = _segment_image_with_cellpose_model(
+            frame,
+            model=prepared.model,
+            diameter=prepared.diameter,
+            cellprob_threshold=prepared.cellprob_threshold,
+            flow_threshold=prepared.flow_threshold,
+        )
+    else:
+        raise ValueError(f"Unknown model type {prepared.model_type}...")
+
+    # `template` carries this frame's pre-rescaling dimensions, so the check is
+    # made per frame rather than assuming every frame matches the first.
+    if Y_pred.shape != template.shape[:2]:
+        Y_pred = _rescale_labels(Y_pred, prepared.scale_model)
+
+    return _check_label_dims(Y_pred, template=template)
+
+
 def segment(
     stack: Union[np.ndarray, List[np.ndarray]],
     model_name: str,
@@ -136,21 +434,6 @@ def segment(
 
     """
 
-    model_path = locate_segmentation_model(model_name)
-    input_config = model_path + "config_input.json"
-    if os.path.exists(input_config):
-        with open(input_config) as config:
-            logger.info("Loading input configuration from 'config_input.json'.")
-            input_config = json.load(config)
-    else:
-        logger.error("Model input configuration could not be located...")
-        return None
-
-    if not use_gpu:
-        os.environ["CUDA_VISIBLE_DEVICES"] = "-1"
-    else:
-        os.environ["CUDA_VISIBLE_DEVICES"] = "0"
-
     if channel_axis != -1:
         stack = np.moveaxis(stack, channel_axis, -1)
 
@@ -158,102 +441,24 @@ def segment(
         if len(channels) != stack.shape[-1]:
             raise ValueError(f"The channel names provided do not match with the expected number of channels in the stack: {stack.shape[-1]}.")
 
-    required_channels = input_config["channels"]
-    channel_intersection = [ch for ch in channels if ch in required_channels]
-    if len(channel_intersection) == 0:
-        raise ValueError("None of the channels required by the model can be found in the images to segment... Abort.")
-
-    channel_indices = _extract_channel_indices(channels, required_channels)
-
-    required_spatial_calibration = input_config["spatial_calibration"]
-    model_type = input_config["model_type"]
-
-    normalize_kwargs = _get_normalize_kwargs_from_config(input_config)
-
-    if model_type == "cellpose":
-        diameter = input_config["diameter"]
-        # if diameter!=30:
-        # 	required_spatial_calibration = None
-        if cellprob_threshold is None:
-            cellprob_threshold = input_config["cellprob_threshold"]
-        if flow_threshold is None:
-            flow_threshold = input_config["flow_threshold"]
-
-    scale = _estimate_scale_factor(spatial_calibration, required_spatial_calibration)
-    logger.info(
-        f"{spatial_calibration=} {required_spatial_calibration=} Scale = {scale}..."
+    prepared = prepare_segmentation_model(
+        model_name,
+        channels=channels,
+        spatial_calibration=spatial_calibration,
+        use_gpu=use_gpu,
+        cellprob_threshold=cellprob_threshold,
+        flow_threshold=flow_threshold,
     )
-
-    model = None
-    if model_type == "stardist":
-        model, scale_model = _prep_stardist_model(
-            model_name, Path(model_path).parent, use_gpu=use_gpu, scale=scale
-        )
-
-    elif model_type == "cellpose":
-        model, scale_model = _prep_cellpose_model(
-            model_path.split("/")[-2],
-            model_path,
-            use_gpu=use_gpu,
-            n_channels=len(required_channels),
-            scale=scale,
-        )
-
-    if model is None:
-        logger.error(f"Could not load model {model_name}. Aborting segmentation.")
+    if prepared is None:
         return None
 
-    labels = []
-
-    # Compute once before the loop: find missing channels and replace None with 0
-    none_channel_indices = np.array([i for i, v in enumerate(channel_indices) if v is None], dtype=int)
-    channel_indices = np.array([v if v is not None else 0 for v in channel_indices])
-
-    for t in tqdm(range(len(stack)), desc="frame"):
-
-        frame = stack[t]
-        frame = _rearrange_multichannel_frame(frame).astype(float)
-
-        frame_to_segment = np.zeros(
-            (frame.shape[0], frame.shape[1], len(required_channels))
-        ).astype(float)
-        for ch in channel_intersection:
-            idx = required_channels.index(ch)
-            frame_to_segment[:, :, idx] = frame[:, :, channels.index(ch)]
-        frame = frame_to_segment
-        template = frame.copy()
-
-        frame = normalize_multichannel(frame, **normalize_kwargs)
-
-        if scale_model is not None:
-            frame = zoom_multiframes(frame, scale_model)
-
-        frame = _fix_no_contrast(frame)
-        frame = interpolate_nan_multichannel(frame)
-        frame[:, :, none_channel_indices] = 0.0
-
-        if model_type == "stardist":
-            Y_pred = _segment_image_with_stardist_model(
-                frame, model=model, return_details=False
-            )
-
-        elif model_type == "cellpose":
-            Y_pred = _segment_image_with_cellpose_model(
-                frame,
-                model=model,
-                diameter=diameter,
-                cellprob_threshold=cellprob_threshold,
-                flow_threshold=flow_threshold,
-            )
-
-        if Y_pred.shape != stack[0].shape[:2]:
-            Y_pred = _rescale_labels(Y_pred, scale_model)
-
-        Y_pred = _check_label_dims(Y_pred, template=template)
-
-        labels.append(Y_pred)
-
-    labels = np.array(labels, dtype=int)
+    labels = np.array(
+        [
+            segment_frame(stack[t], prepared)
+            for t in tqdm(range(len(stack)), desc="frame")
+        ],
+        dtype=int,
+    )
 
     if view_on_napari:
         from celldetective.napari.utils import _view_on_napari

--- a/celldetective/segmentation.py
+++ b/celldetective/segmentation.py
@@ -61,7 +61,7 @@ from celldetective.utils.cellpose_utils import (
 from celldetective.utils.mask_transforms import _rescale_labels
 from celldetective.utils.image_transforms import (
     estimate_unreliable_edge,
-    _estimate_scale_factor,
+    _combined_scale_factor,
     threshold_image,
 )
 from celldetective.utils.data_cleaning import rename_intensity_column
@@ -364,14 +364,11 @@ def prepare_segmentation_model(
     else:
         diameter = None
 
-    scale = _estimate_scale_factor(spatial_calibration, required_spatial_calibration)
-
-    # Correct the scale so that objects come out the size the model was trained
-    # on, mirroring SegmentCellDLProcess.estimate_scale. Both sizes are needed:
+    # Both corrections in one factor, mirroring SegmentCellDLProcess.
     # `cell_size_um` is what the model saw, `target_cell_size_um` what these
-    # images hold.
-    # Read from the model configuration, never from a caller's override: the
-    # override says what to ask Cellpose for, not what the network was trained on.
+    # images hold. Read from the model configuration, never from a caller's
+    # override: the override says what to ask Cellpose for, not what the network
+    # was trained on.
     cell_size = trained_cell_size_um(input_config)
 
     if target_cell_size is None and use_stored_mapping:
@@ -380,11 +377,13 @@ def prepare_segmentation_model(
         raise ValueError(
             f"The target cell size must be strictly positive, got {target_cell_size}."
         )
-    if target_cell_size is not None and cell_size is not None:
-        if scale is not None:
-            scale *= cell_size / target_cell_size
-        elif target_cell_size != cell_size:
-            scale = cell_size / target_cell_size
+
+    scale = _combined_scale_factor(
+        spatial_calibration,
+        required_spatial_calibration,
+        cell_size,
+        target_cell_size,
+    )
 
     logger.info(
         f"{spatial_calibration=} {required_spatial_calibration=} "

--- a/celldetective/utils/downloaders.py
+++ b/celldetective/utils/downloaders.py
@@ -83,6 +83,38 @@ def get_zenodo_files(
         return all_files_short, categories
 
 
+# Transient server- and network-side conditions: the file is expected to be
+# there, the host just could not serve it this second.
+RETRYABLE_HTTP_STATUS = frozenset({408, 425, 429, 500, 502, 503, 504})
+
+
+def _is_retryable(error: Exception) -> bool:
+    """
+    Return whether a failed download attempt is worth repeating.
+
+    Parameters
+    ----------
+    error : Exception
+        The exception raised by the attempt.
+
+    Returns
+    -------
+    bool
+        True for transient conditions (timeouts, dropped connections, 5xx and
+        friends), False for answers that will not change on a retry, such as a
+        404 for a file that is simply not published.
+    """
+
+    import socket
+    from urllib.error import HTTPError, URLError
+
+    if isinstance(error, HTTPError):
+        return error.code in RETRYABLE_HTTP_STATUS
+    if isinstance(error, URLError):
+        return True
+    return isinstance(error, (socket.timeout, ConnectionError, TimeoutError))
+
+
 def download_url_to_file(url: str, dst: str, progress: bool = True) -> None:
     r"""
     Download object at the given URL to a local path.
@@ -97,6 +129,8 @@ def download_url_to_file(url: str, dst: str, progress: bool = True) -> None:
     progress : bool, optional
         Whether to display a progress bar to stderr. Default is True.
     """
+    import random
+    import socket
     import ssl
     import time
     from urllib.error import HTTPError, URLError
@@ -105,12 +139,13 @@ def download_url_to_file(url: str, dst: str, progress: bool = True) -> None:
     ssl._create_default_https_context = ssl._create_unverified_context
 
     # Retry configuration
-    max_retries = 5
-    retry_delay = 10  # Initial delay in seconds
+    max_retries = 7
+    retry_delay = 5  # Initial delay in seconds
+    max_retry_delay = 60  # ~4 min of retries in total, jitter included
 
     for attempt in range(max_retries):
         try:
-            u = urlopen(url)
+            u = urlopen(url, timeout=60)
             meta = u.info()
             if hasattr(meta, "getheaders"):
                 content_length = meta.getheaders("Content-Length")
@@ -119,16 +154,28 @@ def download_url_to_file(url: str, dst: str, progress: bool = True) -> None:
             if content_length is not None and len(content_length) > 0:
                 file_size = int(content_length[0])
             break  # Success
-        except (HTTPError, URLError) as e:
-            if attempt < max_retries - 1:
-                logger.warning(
-                    f"Download check failed: {e}. Retrying in {retry_delay}s..."
+        except (HTTPError, URLError, socket.timeout, OSError) as e:
+            last_attempt = attempt == max_retries - 1
+            if last_attempt or not _is_retryable(e):
+                # A 404 is the host telling us the file is not there; sleeping
+                # through the whole backoff schedule before saying so only
+                # delays the error by minutes.
+                logger.error(
+                    f"Download of {url} failed after {attempt + 1} attempt(s): {e}"
                 )
-                time.sleep(retry_delay)
-                retry_delay *= 2  # Exponential backoff
-            else:
-                logger.error(f"Download check failed after {max_retries} attempts: {e}")
                 raise
+
+            # Zenodo answers 502/504 while it is staging an archive, and the
+            # window can outlast a short schedule. Jitter keeps the parallel CI
+            # jobs from retrying in lockstep and re-timing-out together.
+            delay = min(retry_delay, max_retry_delay)
+            delay += random.uniform(0, delay / 2)
+            logger.warning(
+                f"Download check failed ({e}). "
+                f"Retry {attempt + 2}/{max_retries} in {delay:.0f}s..."
+            )
+            time.sleep(delay)
+            retry_delay = min(retry_delay * 2, max_retry_delay)
 
     # We deliberately save it in a temp file and move it after
     dst = os.path.expanduser(dst)

--- a/celldetective/utils/image_loaders.py
+++ b/celldetective/utils/image_loaders.py
@@ -358,6 +358,7 @@ def locate_labels(
         )
 
     label_names = [os.path.split(lbl)[-1] for lbl in label_path]
+    name_to_idx = {name: i for i, name in enumerate(label_names)}
 
     if frames is None:
 
@@ -389,10 +390,7 @@ def locate_labels(
     elif isinstance(frames, (int, float, np.int_)):
 
         tzfill = str(int(frames)).zfill(4)
-        try:
-            idx = label_names.index(f"{tzfill}.tif")
-        except ValueError:
-            idx = -1
+        idx = name_to_idx.get(f"{tzfill}.tif", -1)
 
         if idx == -1:
             labels = None
@@ -403,10 +401,7 @@ def locate_labels(
         labels = []
         for f in frames:
             tzfill = str(int(f)).zfill(4)
-            try:
-                idx = label_names.index(f"{tzfill}.tif")
-            except ValueError:
-                idx = -1
+            idx = name_to_idx.get(f"{tzfill}.tif", -1)
 
             if idx == -1:
                 labels.append(None)

--- a/celldetective/utils/image_transforms.py
+++ b/celldetective/utils/image_transforms.py
@@ -324,6 +324,86 @@ def _estimate_scale_factor(
     return scale
 
 
+#: Fraction by which a frame may differ from the model's sampling before it is
+#: worth resampling at all. Shared by :func:`_estimate_scale_factor` and
+#: :func:`_combined_scale_factor` so "close enough to 1" means one thing.
+_SCALE_EPSILON = 0.05
+
+
+def _combined_scale_factor(
+    spatial_calibration: Optional[float],
+    required_spatial_calibration: Optional[float],
+    cell_size: Optional[float] = None,
+    target_cell_size: Optional[float] = None,
+) -> Optional[float]:
+    """
+    The single factor a frame must be resized by before it reaches a network.
+
+    Two corrections decide it: the pixel sizes have to match (`spatial_calibration`
+    against `required_spatial_calibration`), and the objects have to arrive at the
+    size the network was trained on (`cell_size` against `target_cell_size`). They
+    multiply.
+
+    Applying :func:`_estimate_scale_factor` first and multiplying afterwards is
+    what this replaces, and it was wrong in one corner: that function collapses a
+    ratio within 5% of 1 to None, meaning "not worth resampling for". That
+    judgement is only true of the calibration correction *on its own*. Once a
+    cell-size correction is also being applied the frame is being resampled
+    regardless, and dropping the calibration factor silently biases the result by
+    up to 5% -- entirely depending on how close the model's own calibration
+    happens to sit to the images'. The two ratios are combined here first, and the
+    "close enough to 1" test is applied once, to the number actually used.
+
+    Parameters
+    ----------
+    spatial_calibration : float or None
+            The images' pixel size. None when unknown, which leaves the
+            calibration correction out.
+    required_spatial_calibration : float or None
+            The pixel size the model was trained at.
+    cell_size : float or None, optional
+            The object size the model was trained on, in microns.
+    target_cell_size : float or None, optional
+            The object size in these images, in microns. Both sizes are needed
+            for the correction; either one missing leaves it out.
+
+    Returns
+    -------
+    float or None
+            The factor to resize by, or None when the frame is already close
+            enough to what the model expects to leave alone.
+
+    Examples
+    --------
+    >>> _combined_scale_factor(0.5, 0.25)
+    2.0
+    >>> _combined_scale_factor(0.2, 0.2075, 6.225, 20.0) is None
+    False
+    """
+
+    scale = 1.0
+    corrected = False
+
+    if spatial_calibration is not None and required_spatial_calibration is not None:
+        scale *= spatial_calibration / required_spatial_calibration
+        corrected = True
+
+    if cell_size is not None and target_cell_size is not None:
+        scale *= cell_size / target_cell_size
+        corrected = True
+
+    if not corrected:
+        return None
+
+    if (1 - _SCALE_EPSILON) <= scale <= (1 + _SCALE_EPSILON):
+        return None
+
+    logger.info(
+        f"Each frame will be rescaled by a factor {scale} to match with the model training data..."
+    )
+    return scale
+
+
 def threshold_image(
     img: np.ndarray,
     min_threshold: float,

--- a/celldetective/utils/mask_cleaning.py
+++ b/celldetective/utils/mask_cleaning.py
@@ -168,12 +168,24 @@ def auto_correct_masks(
 
     Examples
     --------
-    >>> masks = np.array([[0, 0, 1, 1], [0, 2, 2, 1], [0, 2, 0, 0]])
-    >>> corrected_masks = auto_correct_masks(masks)
-    >>> corrected_masks
+    Surviving labels are renumbered consecutively -- 3 and 7 below become 1
+    and 2, which is what keeps downstream label encodings dense:
+
+    >>> masks = np.array([[0, 0, 3, 3],
+    ...                   [0, 7, 7, 3],
+    ...                   [0, 7, 0, 0]])
+    >>> auto_correct_masks(masks, min_area=3)
     array([[0, 0, 1, 1],
-               [0, 2, 2, 1],
-               [0, 2, 0, 0]])
+           [0, 2, 2, 1],
+           [0, 2, 0, 0]])
+
+    Note the explicit ``min_area``: both objects are 3 px, so the default of 9
+    treats them as noise and discards them.
+
+    >>> auto_correct_masks(masks)
+    array([[0, 0, 0, 0],
+           [0, 0, 0, 0],
+           [0, 0, 0, 0]])
     """
 
     if masks.ndim != 2:
@@ -204,7 +216,12 @@ def auto_correct_masks(
     # Second routine: drop objects that are too small and renumber the
     # survivors to consecutive labels (1..N) in a single vectorized pass.
     counts = np.bincount(corrected_lbl.ravel())
-    keep = counts >= min_area
+    # `counts > 0` as well as the area test: `np.bincount` reports a zero count
+    # for every integer below the maximum label, so a `min_area` of 0 or less
+    # would otherwise "keep" label values that are absent from the image, make
+    # the lookup table an identity, and skip the renumbering entirely. Callers
+    # do pass `min_area=0` -- that is what unticking "Remove small objects" sends.
+    keep = (counts >= min_area) & (counts > 0)
     keep[0] = False  # background
     kept_labels = np.nonzero(keep)[0]
     lut = np.zeros(counts.size, dtype=int)

--- a/celldetective/utils/mask_cleaning.py
+++ b/celldetective/utils/mask_cleaning.py
@@ -179,8 +179,9 @@ def auto_correct_masks(
     if masks.ndim != 2:
         raise ValueError("`masks` should be a 2D numpy array...")
 
-    # Avoid negative mask values
-    masks[masks < 0] = np.abs(masks[masks < 0])
+    # Avoid negative mask values. np.abs returns a fresh array, so the caller's
+    # input is never mutated in place.
+    masks = np.abs(masks)
 
     corrected_lbl = masks.copy()  # .astype(int)
 
@@ -188,46 +189,27 @@ def auto_correct_masks(
         props = pd.DataFrame(
             regionprops_table(masks, properties=("label", "area", "area_bbox"))
         )
-        max_lbl = props["label"].max()
+        max_lbl = int(props["label"].max()) if len(props) else 0
 
-        for cell in props["label"].unique():
+        for row in props.itertuples(index=False):
 
-            bbox_area = props.loc[props["label"] == cell, "area_bbox"].values
-            area = props.loc[props["label"] == cell, "area"].values
+            if row.area_bbox > bbox_factor * row.area:  # condition for anomaly
 
-            if bbox_area > bbox_factor * area:  # condition for anomaly
-
-                lbl = masks == cell
-                lbl = lbl.astype(int)
-
+                lbl = masks == row.label
                 relabelled = label(lbl, connectivity=2)
-                relabelled += max_lbl
-                relabelled[np.where(lbl == 0)] = 0
+                relabelled[lbl] += max_lbl
+                corrected_lbl[lbl] = relabelled[lbl]
+                max_lbl = int(corrected_lbl.max())
 
-                corrected_lbl[np.where(relabelled != 0)] = relabelled[
-                    np.where(relabelled != 0)
-                ]
-
-            max_lbl = np.amax(corrected_lbl)
-
-    # Second routine to eliminate objects too small
-    props2 = pd.DataFrame(
-        regionprops_table(corrected_lbl, properties=("label", "area", "area_bbox"))
-    )
-    for cell in props2["label"].unique():
-        area = props2.loc[props2["label"] == cell, "area"].values
-        lbl = corrected_lbl == cell
-        if area < min_area:
-            corrected_lbl[lbl] = 0
-
-    # Additionnal routine to reorder labels from 1 to number of cells
-    label_ids = np.unique(corrected_lbl)[1:]
-    clean_labels = corrected_lbl.copy()
-
-    for k, lbl in enumerate(label_ids):
-        clean_labels[corrected_lbl == lbl] = k + 1
-
-    clean_labels = clean_labels.astype(int)
+    # Second routine: drop objects that are too small and renumber the
+    # survivors to consecutive labels (1..N) in a single vectorized pass.
+    counts = np.bincount(corrected_lbl.ravel())
+    keep = counts >= min_area
+    keep[0] = False  # background
+    kept_labels = np.nonzero(keep)[0]
+    lut = np.zeros(counts.size, dtype=int)
+    lut[kept_labels] = np.arange(1, kept_labels.size + 1)
+    clean_labels = lut[corrected_lbl].astype(int)
 
     if fill_labels:
         clean_labels = fill_label_holes(clean_labels)
@@ -325,10 +307,19 @@ def relabel_segmentation(
 
     new_labels = np.zeros_like(labels)
     shared_data = {"s": 0}
+    label_lock = threading.Lock()  # shared lock guarding `shared_data["s"]`
+
+    # Pre-group the trajectory table by frame once, so the worker loop does a
+    # dict lookup per frame instead of a full-DataFrame scan.
+    frame_col = column_labels["frame"]
+    cells_by_frame = {
+        int(f): g[[column_labels["track"], column_labels["label"]]].to_numpy()
+        for f, g in df.dropna(subset=[frame_col]).groupby(frame_col)
+    }
 
     # Progress tracking
     shared_progress = {"val": 0, "lock": threading.Lock()}
-    total_frames = len(df[column_labels["frame"]].dropna().unique())
+    total_frames = len(cells_by_frame)
 
     def rewrite_labels(indices: List[int]) -> None:
         """
@@ -341,6 +332,7 @@ def relabel_segmentation(
         """
 
         all_track_ids = df[column_labels["track"]].dropna().unique()
+        max_track_id = max(all_track_ids) if len(all_track_ids) else 0
 
         # Check for cancellation
         if progress_callback:
@@ -367,10 +359,7 @@ def relabel_segmentation(
                     return
 
             f = int(t)
-            cells = df.loc[
-                df[column_labels["frame"]] == f,
-                [column_labels["track"], column_labels["label"]],
-            ].to_numpy()
+            cells = cells_by_frame.get(f, np.empty((0, 2)))
             tracks_at_t = list(cells[:, 0])
             identities = list(cells[:, 1])
 
@@ -379,28 +368,30 @@ def relabel_segmentation(
                 labels_at_t.remove(0)
             labels_not_in_df = [lbl for lbl in labels_at_t if lbl not in identities]
             for lbl in labels_not_in_df:
-                with threading.Lock():  # Synchronize access to `shared_data["s"]`
-                    track_id = max(all_track_ids) + shared_data["s"]
+                with label_lock:  # Synchronize access to `shared_data["s"]`
+                    track_id = max_track_id + shared_data["s"]
                     shared_data["s"] += 1
                 tracks_at_t.append(track_id)
                 identities.append(lbl)
 
-            # exclude NaN
+            # Drop NaN identities/tracks, then rewrite the whole frame in a
+            # single lookup-table pass (label value -> track id).
             tracks_at_t = np.array(tracks_at_t)
             identities = np.array(identities)
+            valid = (identities == identities) & (tracks_at_t == tracks_at_t)
+            identities = identities[valid]
+            tracks_at_t = tracks_at_t[valid]
 
-            tracks_at_t = tracks_at_t[identities == identities]
-            identities = identities[identities == identities]
-
-            for k in range(len(identities)):
-
-                # need routine to check values from labels not in class_id of this frame and add new track id
-
-                loc_i, loc_j = np.where(labels[f] == identities[k])
-                track_id = tracks_at_t[k]
-
-                if track_id == track_id:
-                    new_labels[f, loc_i, loc_j] = round(track_id)
+            if identities.size:
+                frame = labels[f]
+                max_lbl = int(frame.max())
+                ids_int = identities.astype(np.int64)
+                in_range = (ids_int >= 0) & (ids_int <= max_lbl)
+                lut = np.zeros(max_lbl + 1, dtype=new_labels.dtype)
+                lut[ids_int[in_range]] = np.round(tracks_at_t[in_range]).astype(
+                    new_labels.dtype
+                )
+                new_labels[f] = lut[frame]
 
     # Multithreading
     indices = list(df[column_labels["frame"]].dropna().unique())

--- a/celldetective/utils/masks.py
+++ b/celldetective/utils/masks.py
@@ -113,29 +113,31 @@ def contour_of_instance_segmentation(
         return np.zeros_like(label)
 
     if sdf is None or voronoi_map is None:
-        # Compute SDF maps
-        # We need SDF = dist_in - dist_out
-        # inside > 0, outside < 0
+        # An outer contour (any part of the range outside the object) needs the
+        # exterior distance transform *and* the Voronoi feature transform to
+        # propagate instance identity into the background. An inner contour
+        # (min_r >= 0) stays inside the objects, where identity is just `label`,
+        # so we can skip both the second EDT and the (costly) feature transform.
+        if min_r < 0:
+            dist_in = distance_transform_edt(label > 0)
+            dist_out, indices = distance_transform_edt(
+                label == 0, return_indices=True
+            )
+            voronoi_map = label[indices[0], indices[1]]
+            sdf = dist_in - dist_out
 
-        # 1. Dist In (Inside object)
+            mask = (sdf >= min_r) & (sdf <= max_r)
+            return voronoi_map * mask
+
+        # Inner-only: interior EDT is enough. dist_in == 0 in the background,
+        # so mask it out explicitly (matters when min_r == 0).
         dist_in = distance_transform_edt(label > 0)
+        mask = (dist_in >= min_r) & (dist_in <= max_r) & (label > 0)
+        return label * mask
 
-        # 2. Dist Out (Outside object) + Voronoi
-        dist_out, indices = distance_transform_edt(label == 0, return_indices=True)
-
-        # Voronoi Map
-        voronoi_map = label[indices[0], indices[1]]
-
-        # Composite SDF
-        sdf = dist_in - dist_out
-
-    # Create Mask
+    # Pre-computed SDF / Voronoi provided by the caller.
     mask = (sdf >= min_r) & (sdf <= max_r)
-
-    # Result
-    border_label = voronoi_map * mask
-
-    return border_label
+    return voronoi_map * mask
 
 
 def create_patch_mask(
@@ -188,10 +190,10 @@ def create_patch_mask(
     Y, X = np.ogrid[:h, :w]
     dist_from_center = np.sqrt((X - center[0]) ** 2 + (Y - center[1]) ** 2)
 
-    if isinstance(radius, int) or isinstance(radius, float):
+    if isinstance(radius, (list, tuple, np.ndarray)):
+        mask = (dist_from_center <= radius[1]) & (dist_from_center >= radius[0])
+    elif isinstance(radius, (int, float, np.integer, np.floating)):
         mask = dist_from_center <= radius
-    elif isinstance(radius, list):
-        mask = (dist_from_center <= radius[1]) * (dist_from_center >= radius[0])
     else:
         logger.error("Please provide a proper format for the radius")
         return None

--- a/celldetective/utils/maths.py
+++ b/celldetective/utils/maths.py
@@ -109,31 +109,38 @@ def derivative(
     array([3., 3., 3., 3.])
     """
 
-    # modes = bi, forward, backward
-    dxdt = np.zeros(len(x))
-    dxdt[:] = np.nan
+    dxdt = np.full(len(x), np.nan)
 
     if mode == "bi":
         if window % 2 != 1:
             raise ValueError("Please set an odd window for the bidirectional mode")
         lower_bound = window // 2
         upper_bound = len(x) - window // 2
+        if upper_bound > lower_bound:
+            half_window = window // 2
+            dxdt[lower_bound:upper_bound] = (
+                (x[lower_bound + half_window : upper_bound + half_window] - 
+                 x[lower_bound - half_window : upper_bound - half_window]) /
+                (timeline[lower_bound + half_window : upper_bound + half_window] - 
+                 timeline[lower_bound - half_window : upper_bound - half_window])
+            )
     elif mode == "forward":
         lower_bound = 0
         upper_bound = len(x) - window
+        if upper_bound > lower_bound:
+            dxdt[lower_bound:upper_bound] = (
+                (x[lower_bound + window : upper_bound + window] - x[lower_bound:upper_bound]) /
+                (timeline[lower_bound + window : upper_bound + window] - timeline[lower_bound:upper_bound])
+            )
     elif mode == "backward":
         lower_bound = window
         upper_bound = len(x)
-
-    for t in range(lower_bound, upper_bound):
-        if mode == "bi":
-            dxdt[t] = (x[t + window // 2] - x[t - window // 2]) / (
-                timeline[t + window // 2] - timeline[t - window // 2]
+        if upper_bound > lower_bound:
+            dxdt[lower_bound:upper_bound] = (
+                (x[lower_bound:upper_bound] - x[lower_bound - window : upper_bound - window]) /
+                (timeline[lower_bound:upper_bound] - timeline[lower_bound - window : upper_bound - window])
             )
-        elif mode == "forward":
-            dxdt[t] = (x[t + window] - x[t]) / (timeline[t + window] - timeline[t])
-        elif mode == "backward":
-            dxdt[t] = (x[t] - x[t - window]) / (timeline[t] - timeline[t - window])
+
     return dxdt
 
 
@@ -160,18 +167,32 @@ def differentiate_per_track(
         Tracking data with derivative column.
     """
 
+    new_col = "d/dt." + measurement
+    
+    if len(tracks) == 0:
+        tracks[new_col] = np.array([], dtype=float)
+        return tracks
+
     groupby_cols = ["TRACK_ID"]
     if "position" in list(tracks.columns):
         groupby_cols = ["position"] + groupby_cols
 
     tracks = tracks.sort_values(by=groupby_cols + ["FRAME"], ignore_index=True)
-    tracks = tracks.reset_index(drop=True)
-    for tid, group in tracks.groupby(groupby_cols):
-        indices = group.index
-        timeline = group["FRAME"].values
-        signal = group[measurement].values
-        dsignal = derivative(signal, timeline, window_size, mode=mode)
-        tracks.loc[indices, "d/dt." + measurement] = dsignal
+    dsignal = np.empty(len(tracks))
+    dsignal[:] = np.nan
+
+    # Filled by position rather than through groupby.apply: with a single group,
+    # apply reads the per-group Series as columns and hands back a DataFrame,
+    # which cannot be assigned to one column.
+    for _, group in tracks.groupby(groupby_cols, sort=False):
+        dsignal[group.index] = derivative(
+            group[measurement].values,
+            group["FRAME"].values,
+            window_size,
+            mode=mode,
+        )
+
+    tracks[new_col] = dsignal
     return tracks
 
 
@@ -196,20 +217,26 @@ def velocity_per_track(
         Tracking data with velocity column.
     """
 
+    if len(tracks) == 0:
+        tracks["velocity"] = np.array([], dtype=float)
+        return tracks
+
     groupby_cols = ["TRACK_ID"]
     if "position" in list(tracks.columns):
         groupby_cols = ["position"] + groupby_cols
 
     tracks = tracks.sort_values(by=groupby_cols + ["FRAME"], ignore_index=True)
-    tracks = tracks.reset_index(drop=True)
-    for tid, group in tracks.groupby(groupby_cols):
+    velocity_values = np.empty(len(tracks))
+    velocity_values[:] = np.nan
+    
+    for _, group in tracks.groupby(groupby_cols):
         indices = group.index
-        timeline = group["FRAME"].values
-        x = group["POSITION_X"].values
-        y = group["POSITION_Y"].values
-        v = velocity(x, y, timeline, window=window_size, mode=mode)
+        v = velocity(group["POSITION_X"].values, group["POSITION_Y"].values, 
+                    group["FRAME"].values, window=window_size, mode=mode)
         v_abs = magnitude_velocity(v)
-        tracks.loc[indices, "velocity"] = v_abs
+        velocity_values[indices] = v_abs
+    
+    tracks["velocity"] = velocity_values
     return tracks
 
 
@@ -318,11 +345,7 @@ def magnitude_velocity(v_matrix: np.ndarray) -> np.ndarray:
     array([5., nan, nan])
     """
 
-    magnitude = np.zeros(len(v_matrix))
-    magnitude[:] = np.nan
-    for i in range(len(v_matrix)):
-        if v_matrix[i, 0] == v_matrix[i, 0]:
-            magnitude[i] = np.sqrt(v_matrix[i, 0] ** 2 + v_matrix[i, 1] ** 2)
+    magnitude = np.sqrt(v_matrix[:, 0] ** 2 + v_matrix[:, 1] ** 2)
     return magnitude
 
 
@@ -358,11 +381,7 @@ def orientation(v_matrix: np.ndarray) -> np.ndarray:
     array([0.92729522, nan, nan])
     """
 
-    orientation_array = np.zeros(len(v_matrix))
-    for t in range(len(orientation_array)):
-        if v_matrix[t, 0] == v_matrix[t, 0]:
-            orientation_array[t] = np.arctan2(v_matrix[t, 0], v_matrix[t, 1])
-    return orientation_array
+    return np.arctan2(v_matrix[:, 0], v_matrix[:, 1])
 
 
 def safe_log(array: Union[int, float, List, np.ndarray]) -> Union[float, np.ndarray]:

--- a/celldetective/utils/model_getters.py
+++ b/celldetective/utils/model_getters.py
@@ -188,7 +188,7 @@ def get_pair_signal_models_list(
 
 
 def get_segmentation_models_list(
-    mode: str = "targets", return_path: bool = False
+    mode: str = "targets", return_path: bool = False, cleanup: bool = True
 ) -> Union[List[str], Tuple[List[str], str]]:
     """
     Get available segmentation models.
@@ -199,6 +199,12 @@ def get_segmentation_models_list(
         Segmentation mode ("targets" or "effectors"). Default is "targets".
     return_path : bool, optional
         If True, return path to models. Default is False.
+    cleanup : bool, optional
+        If True, create the category directory when it is missing and delete any
+        local model directory that has no ``config_input.json`` - a model in that
+        state cannot be loaded, and leaving it in place makes it reappear in every
+        list. Set to False to list without touching the disk, for callers that are
+        only asking what is available. Default is True.
 
     Returns
     -------
@@ -216,8 +222,16 @@ def get_segmentation_models_list(
         ]
     )
     if not os.path.exists(modelpath):
-        os.mkdir(modelpath)
-        repository_models = []
+        if cleanup:
+            os.mkdir(modelpath)
+            repository_models = []
+        else:
+            # Listing the repository only reads a bundled JSON, so a caller that
+            # is not allowed to create the category directory can still be told
+            # what is downloadable into it.
+            repository_models = get_zenodo_files(
+                cat=os.sep.join(["models", f"segmentation_{mode}"])
+            )
     else:
         repository_models = get_zenodo_files(
             cat=os.sep.join(["models", f"segmentation_{mode}"])
@@ -232,7 +246,8 @@ def get_segmentation_models_list(
         path = modelpath + model
         files = glob(path + os.sep + "*")
         if path + os.sep + "config_input.json" not in files:
-            rmtree(path)
+            if cleanup:
+                rmtree(path)
             to_remove.append(model)
     for m in to_remove:
         available_models.remove(m)

--- a/celldetective/utils/model_loaders.py
+++ b/celldetective/utils/model_loaders.py
@@ -8,6 +8,73 @@ from celldetective.utils.downloaders import get_zenodo_files, download_zenodo_fi
 logger = logging.getLogger("celldetective")
 
 
+def trained_cell_size_um(input_config: Optional[dict]) -> Optional[float]:
+    """
+    The physical object size a segmentation model was trained on, in microns.
+
+    This is the size the rescaling is measured against: a frame is resized until
+    its objects reach the size the network was trained to see, so both readings
+    have to come from the same place wherever that is worked out -- the library,
+    the main window's channel dialog, or the napari single-frame panel.
+
+    A model built through celldetective records the size directly as
+    ``cell_size_um``. A generic Cellpose model does not, but it states the same
+    thing in pixels: it was trained to see objects ``diameter`` px across, at its
+    own ``spatial_calibration``, so the product is that size in microns. Without
+    the second reading a generic model cannot be rescaled at all -- the
+    correction needs the trained size and the target, and one of them is missing.
+
+    Parameters
+    ----------
+    input_config : dict or None
+            A model's ``config_input.json``, already parsed.
+
+    Returns
+    -------
+    float or None
+            The trained object size in microns, or None when the configuration
+            gives no way to work it out -- in which case there is nothing to
+            rescale against.
+
+    Examples
+    --------
+    >>> trained_cell_size_um({'cell_size_um': 9.211})
+    9.211
+    >>> trained_cell_size_um(
+    ...     {'model_type': 'cellpose', 'diameter': 30.0, 'spatial_calibration': 0.5}
+    ... )
+    15.0
+    """
+
+    if not input_config:
+        return None
+
+    cell_size = input_config.get("cell_size_um")
+    if cell_size is not None:
+        # Comes from the model's own configuration, so a nonsensical value is
+        # worth saying out loud rather than quietly scaling everything to nothing.
+        if cell_size > 0:
+            return cell_size
+        logger.warning(
+            f"Ignoring cell_size_um={cell_size}: it must be strictly positive."
+        )
+        return None
+
+    if input_config.get("model_type") != "cellpose":
+        return None
+
+    diameter = input_config.get("diameter")
+    calibration = input_config.get("spatial_calibration")
+    if (
+        diameter is not None
+        and calibration is not None
+        and diameter > 0
+        and calibration > 0
+    ):
+        return diameter * calibration
+    return None
+
+
 def locate_signal_model(
     name: str, path: Optional[str] = None, pairs: bool = False
 ) -> Optional[str]:

--- a/celldetective/utils/model_loaders.py
+++ b/celldetective/utils/model_loaders.py
@@ -199,6 +199,17 @@ def locate_segmentation_model(name: str, download: bool = True) -> Optional[str]
     match = None
     for m in models:
         if name == m.replace("\\", os.sep).split(os.sep)[-2]:
+            if not os.path.exists(os.sep.join([m.rstrip(os.sep), "config_input.json"])):
+                # An interrupted download leaves the directory behind without its
+                # input configuration. Matching on the name alone would hand back
+                # a model that can never be loaded, and would shadow the copy on
+                # Zenodo forever; treat it as absent so the download below can
+                # overwrite it.
+                logger.warning(
+                    f"Ignoring incomplete local model {name} in {m}: "
+                    "no 'config_input.json'."
+                )
+                continue
             match = m
             return match
     if download:

--- a/celldetective/utils/normalization.py
+++ b/celldetective/utils/normalization.py
@@ -3,6 +3,13 @@ from typing import Optional, Union, Tuple, List, Any
 
 import numpy as np
 
+# Try to import numexpr at module level for faster access
+try:
+    import numexpr
+    HAS_NUMEXPR = True
+except ImportError:
+    HAS_NUMEXPR = False
+
 
 def normalize_mi_ma(
     x: np.ndarray,
@@ -41,11 +48,10 @@ def normalize_mi_ma(
         mi = dtype(mi) if np.isscalar(mi) else mi.astype(dtype, copy=False)
         ma = dtype(ma) if np.isscalar(ma) else ma.astype(dtype, copy=False)
         eps = dtype(eps)
-    try:
-        import numexpr
-
-        x = numexpr.evaluate("(x - mi) / ( ma - mi + eps )")
-    except ImportError:
+    
+    if HAS_NUMEXPR:
+        x = numexpr.evaluate("(x - mi) / (ma - mi + eps)")
+    else:
         x = (x - mi) / (ma - mi + eps)
 
     if clip:
@@ -119,31 +125,38 @@ def normalize(
 
     frame = frame.astype(float)
 
+    # Cache the mask and flattened array to avoid redundant operations
     if ignore_gray_value is not None:
-        subframe = frame[frame != ignore_gray_value]
+        mask = frame != ignore_gray_value
+        subframe_flat = frame[mask].flatten()
     else:
-        subframe = frame.copy()
+        mask = None
+        subframe_flat = frame.flatten()
 
     if values is not None:
         mi = values[0]
         ma = values[1]
     else:
-        mi = np.nanpercentile(subframe.flatten(), percentiles[0], keepdims=True)
-        ma = np.nanpercentile(subframe.flatten(), percentiles[1], keepdims=True)
+        # Compute percentiles once from cached flattened array
+        mi = np.nanpercentile(subframe_flat, percentiles[0])
+        ma = np.nanpercentile(subframe_flat, percentiles[1])
 
-    frame0 = frame.copy()
-    frame = normalize_mi_ma(frame0, mi, ma, clip=False, eps=1e-20, dtype=np.float32)
+    # Store original frame only if needed for ignore_gray_value masking
+    frame_orig = frame.copy() if mask is not None else None
+    frame = normalize_mi_ma(frame, mi, ma, clip=False, eps=1e-20, dtype=np.float32)
+    
     if amplification is not None:
         frame *= amplification
+    
     if clip:
         if amplification is None:
             amplification = 1.0
-        frame[frame >= amplification] = amplification
-        frame[frame <= 0.0] = 0.0
-    if ignore_gray_value is not None:
-        frame[frame0 == ignore_gray_value] = ignore_gray_value
+        frame = np.clip(frame, 0.0, amplification)
+    
+    if mask is not None:
+        frame[~mask] = frame_orig[~mask]
 
-    return frame.copy().astype(dtype)
+    return frame.astype(dtype)
 
 
 def normalize_multichannel(
@@ -220,28 +233,31 @@ def normalize_multichannel(
         if len(values) != mf.shape[-1]:
             raise ValueError("Mismatch between the normalization values provided and the number of channels.")
 
-    mf_new = []
+    # Pre-allocate output array to avoid building list and moveaxis overhead
+    mf_normalized = np.zeros_like(mf, dtype=np.float32)
+    
     for c in range(mf.shape[-1]):
-        if values is not None:
-            v = values[c]
-        else:
-            v = None
-
+        # Skip all-zero channels: they're already zero in the pre-allocated array,
+        # and processing them would cause empty-slice warnings when ignore_gray_value=0.0
+        # Plus it matches the old behavior for edge cases like values=(10,200) on dead channels
         if np.all(mf[:, :, c] == 0.0):
-            mf_new.append(mf[:, :, c].copy())
-        else:
-            norm = normalize(
-                mf[:, :, c].copy(),
-                percentiles=percentiles[c],
-                values=v,
-                ignore_gray_value=ignore_gray_value,
-                clip=clip,
-                amplification=amplification,
-                dtype=dtype,
-            )
-            mf_new.append(norm)
+            continue
+        
+        # Get normalization values for this channel
+        v = values[c] if values is not None else None
+        
+        # Normalize channel
+        mf_normalized[:, :, c] = normalize(
+            mf[:, :, c],
+            percentiles=percentiles[c],
+            values=v,
+            ignore_gray_value=ignore_gray_value,
+            clip=clip,
+            amplification=amplification,
+            dtype=np.float32,
+        )
 
-    return np.moveaxis(mf_new, 0, -1)
+    return mf_normalized.astype(dtype)
 
 
 def get_stack_normalization_values(
@@ -389,34 +405,37 @@ def normalize_per_channel(
 
     X_normalized = []
     for i in range(len(X)):
-        x = X[i].copy()
+        x = X[i].copy().astype(float)
+        
+        # Find all zero locations once for the entire image
         loc_i, loc_j, loc_c = np.where(x == 0.0)
         norm_x = np.zeros_like(x, dtype=np.float32)
+        
         for k in range(x.shape[-1]):
-            chan = x[:, :, k].copy()
-            if not np.all(chan.flatten() == 0):
+            # Use view instead of copy; check for non-zero more efficiently
+            chan = x[:, :, k]
+            if np.any(chan != 0.0):
                 if normalization_percentile_mode[k]:
-                    min_val = np.nanpercentile(
-                        chan[chan != 0.0].flatten(), normalization_values[k][0]
-                    )
-                    max_val = np.nanpercentile(
-                        chan[chan != 0.0].flatten(), normalization_values[k][1]
-                    )
+                    non_zero_vals = chan[chan != 0.0].flatten()
+                    min_val = np.nanpercentile(non_zero_vals, normalization_values[k][0])
+                    max_val = np.nanpercentile(non_zero_vals, normalization_values[k][1])
                 else:
                     min_val = normalization_values[k][0]
                     max_val = normalization_values[k][1]
 
                 clip_option = normalization_clipping[k]
+                # chan is already float, no astype needed
                 norm_x[:, :, k] = normalize_mi_ma(
-                    chan.astype(np.float32).copy(),
+                    chan,
                     min_val,
                     max_val,
                     clip=clip_option,
                     eps=1e-20,
                     dtype=np.float32,
                 )
-            else:
-                norm_x[:, :, k] = 0.0
+            # else: norm_x already zero, no need to set
+        
+        # Restore original zeros
         norm_x[loc_i, loc_j, loc_c] = 0.0
         X_normalized.append(norm_x.copy())
 

--- a/celldetective/utils/stardist_utils/__init__.py
+++ b/celldetective/utils/stardist_utils/__init__.py
@@ -11,6 +11,35 @@ os.environ["TF_CPP_MIN_LOG_LEVEL"] = "3"
 import numpy as np
 
 
+def _stardist_gpu_usable() -> bool:
+    """
+    Return True only if StarDist can actually run its gputools/OpenCL non-maximum
+    suppression on the GPU.
+
+    ``stardist.gputools_available`` only checks that ``gputools`` imports; it does
+    not confirm a working OpenCL device. We additionally probe for a real device
+    (``gputools.get_device`` raises when none is usable) so we can fall back to CPU
+    instead of failing at predict time, mirroring the Cellpose GPU check.
+    """
+    try:
+        from stardist import gputools_available
+    except ImportError:
+        return False
+
+    if not gputools_available():
+        return False
+
+    try:
+        import gputools
+
+        gputools.get_device()
+    except Exception as e:  # no OpenCL platform/device, driver issue, etc.
+        logger.debug(f"gputools imported but no usable OpenCL device: {e}")
+        return False
+
+    return True
+
+
 def _prep_stardist_model(
     model_name: str, path: Union[str, Path], use_gpu: bool = False, scale: float = 1
 ):
@@ -53,6 +82,16 @@ def _prep_stardist_model(
             "StarDist is not installed. Please install it to use this feature.\n"
             "You can install the full package with: pip install celldetective[all]"
         ) from e
+
+    if use_gpu and not _stardist_gpu_usable():
+        # StarDist's config.use_gpu drives the gputools/OpenCL non-maximum
+        # suppression path; enabling it without a usable OpenCL device makes NMS
+        # fail at predict time. Mirror the Cellpose path and fall back to CPU.
+        logger.warning(
+            "GPU requested for StarDist but no usable gputools/OpenCL device was found. "
+            "Falling back to CPU for non-maximum suppression."
+        )
+        use_gpu = False
 
     model = StarDist2D(None, name=model_name, basedir=path)
     model.config.use_gpu = use_gpu

--- a/docs/source/segment.rst
+++ b/docs/source/segment.rst
@@ -203,6 +203,47 @@ To train a model on your annotations, see :doc:`How to train a segmentation mode
     **napari**. napari provides the basic requirements of image manipulation software, namely a brush, rubber, bucket and pipette, to work on the segmentation layer. In this RICM image of spreading NK cells, two couples of cells have been mistakenly segmented as one object and must be separated. On the right panel, two plugins specific to Celldetective allow 1) the export of the modified masks directly in the position folder, and 2) to create automatically an annotation consisting of the current multichannel frame, the modified mask and a configuration file specifying the modality content of the image and its spatial calibration.
 
 
+Segmenting a single frame from napari
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+The top of the same right-hand panel can run a segmentation model on the frame
+currently on screen, without leaving the viewer or launching a run over the whole
+position. It is the quickest way to try a model, a channel mapping or a threshold
+on one frame and look at the result straight away.
+
+*   **model** — any model available for this population, plus the generic ones.
+    A model that has not been downloaded yet is offered too; it is fetched on the
+    first run.
+*   **channels** — one dropdown per input slot of the chosen model, seeded from
+    the mapping already saved by the import dialog. Set a slot to ``None`` to
+    leave it blank. The same experiment channel may feed several slots.
+*   **parameters** — the values that model type actually takes: **diameter**,
+    **cell probability** and **flow threshold** for Cellpose models, and **cell
+    size** wherever the model declares the size it was trained on. Leave a field
+    blank to use the model's own value.
+*   **Replace the labels on this frame** — ticked, the frame is segmented afresh.
+    Unticked, the existing labels are kept and the new ones only fill the
+    background, so manual corrections on that frame survive.
+
+The run happens on a background thread, so the viewer stays usable; the button
+turns into **Cancel** while it works. Inference itself cannot be interrupted, so
+cancelling during a forward pass returns the interface to normal and discards the
+result when it lands, while cancelling during model loading stops before any
+inference happens.
+
+The result is written into the ``segmentation`` layer and can be undone with
+:kbd:`Ctrl+Z` like any other edit. Nothing reaches disk until **Save the modified
+labels** is used, and the settings chosen here stay local to the napari session:
+they are never written back into the model configuration, so trying something out
+cannot change what the next full-position run does.
+
+.. note::
+
+    Segmentation here runs on the CPU, leaving the GPU to the viewer's renderer.
+    A single frame is quick, but expect it to be slower than the same model
+    running over a position in the main window.
+
+
 References
 ----------
 

--- a/docs/source/segment.rst
+++ b/docs/source/segment.rst
@@ -214,9 +214,10 @@ on one frame and look at the result straight away.
 *   **model** — any model available for this population, plus the generic ones.
     A model that has not been downloaded yet is offered too; it is fetched on the
     first run.
-*   **channels** — one dropdown per input slot of the chosen model, seeded from
-    the mapping already saved by the import dialog. Set a slot to ``None`` to
-    leave it blank. The same experiment channel may feed several slots.
+*   **channels** — the same rows as the channel dialog of the main window: one
+    dropdown per input slot of the chosen model, seeded from the mapping already
+    saved there. Set a slot to ``None`` to leave it blank. The same experiment
+    channel may feed several slots.
 *   **parameters** — the values that model type actually takes: **diameter**,
     **cell probability** and **flow threshold** for Cellpose models, and **cell
     size** wherever the model declares the size it was trained on. Leave a field

--- a/docs/source/segment.rst
+++ b/docs/source/segment.rst
@@ -168,6 +168,15 @@ Importing and applying models
 
 Models are imported via the :icon:`upload,black` button in the Segmentation panel. This creates a configuration file that maps your experiment's channels to the model's expected inputs, including spatial calibration and normalization.
 
+When you set the channels for a model, the dialog also asks for the **cell size**
+in microns whenever the model has a trained size to be rescaled against: the
+frame is resized until its objects reach the size the network was trained to see.
+Models built through celldetective record that size as ``cell_size_um``; a
+generalist Cellpose model records it in pixels instead, as the diameter it was
+trained on at its own calibration, so it is asked for those too. The dialog
+reopens on the size you last set, and a model with no trained size is never given
+one behind your back.
+
 For a detailed list of all import parameters, see the :ref:`Segmentation Data Import Reference <ref_segmentation_settings>`.
 
 For a complete step-by-step walkthrough (including generalist model configuration), see :doc:`How to apply a segmentation model <how-to-guides/basics/apply-a-segmentation-model>`.
@@ -218,10 +227,20 @@ on one frame and look at the result straight away.
     dropdown per input slot of the chosen model, seeded from the mapping already
     saved there. Set a slot to ``None`` to leave it blank. The same experiment
     channel may feed several slots.
-*   **parameters** — the values that model type actually takes: **diameter**,
-    **cell probability** and **flow threshold** for Cellpose models, and **cell
-    size** wherever the model declares the size it was trained on. Leave a field
+*   **parameters** — the values that model type actually takes: **cell
+    probability** and **flow threshold** for Cellpose models, and **cell size**
+    for every model whose trained object size can be worked out. Leave a field
     blank to use the model's own value.
+
+    **Cell size** is the typical object size in *these* images, in microns, and
+    it is what drives the rescaling: the frame is resized until objects reach the
+    size the network was trained to see, which is where a model does its best
+    work. A model built through celldetective records that size as
+    ``cell_size_um``; a generic Cellpose model records it in pixels instead, as
+    the diameter it was trained on at its own calibration, so the row is offered
+    for those too. The trained size itself — Cellpose's 30 px, say — is not a
+    setting and is never asked for: a network trained to see 30 px objects should
+    go on being asked for 30 px ones, and it is the image that moves.
 *   **Replace the labels on this frame** — ticked, the frame is segmented afresh.
     Unticked, the existing labels are kept and the new ones only fill the
     background, so manual corrections on that frame survive.

--- a/tests/gui/test_frame_segmentation_panel.py
+++ b/tests/gui/test_frame_segmentation_panel.py
@@ -1,0 +1,262 @@
+"""
+Unit tests for the napari single-frame segmentation panel.
+
+Covers the parts that can be exercised without a napari viewer or a real model:
+the label-writing rules (dtype safety, merging, undo), the prepared-model cache,
+and the model listing. The panel itself is built against a stub viewer, so these
+stay fast and do not touch the GPU or the model repository.
+"""
+
+import logging
+from collections import OrderedDict
+from unittest.mock import MagicMock
+
+import numpy as np
+import pytest
+
+from celldetective.napari import frame_segmentation as fs
+
+
+@pytest.fixture(autouse=True)
+def disable_logging():
+    """Disable all logging to avoid Windows OSError with pytest capture."""
+    logging.disable(logging.CRITICAL)
+    yield
+    logging.disable(logging.NOTSET)
+
+
+class TestFitToLayerDtype:
+    """
+    Labels must never be wrapped round to fit the layer.
+
+    napari keeps the labels in the integer type they were read as, often uint16.
+    A silent wrap merges unrelated cells under one identifier, and nothing
+    downstream can tell that apart from a genuine segmentation.
+    """
+
+    def test_labels_that_fit_are_cast(self):
+        labels = np.array([[0, 1], [2, 3]], dtype=np.int64)
+        out = fs._fit_to_layer_dtype(labels, np.dtype(np.uint16))
+        assert out.dtype == np.uint16
+        np.testing.assert_array_equal(out, labels)
+
+    def test_labels_that_do_not_fit_are_refused(self):
+        labels = np.array([[0, 70000]], dtype=np.int64)
+        with pytest.raises(ValueError) as excinfo:
+            fs._fit_to_layer_dtype(labels, np.dtype(np.uint16))
+        assert "70000" in str(excinfo.value)
+        assert "65535" in str(excinfo.value)
+
+    def test_the_remedy_is_included_in_the_message(self):
+        labels = np.array([[300]], dtype=np.int64)
+        with pytest.raises(ValueError) as excinfo:
+            fs._fit_to_layer_dtype(labels, np.dtype(np.uint8), "Do the other thing.")
+        assert "Do the other thing." in str(excinfo.value)
+
+    def test_an_empty_frame_is_allowed(self):
+        labels = np.zeros((0, 0), dtype=np.int64)
+        assert fs._fit_to_layer_dtype(labels, np.dtype(np.uint8)).dtype == np.uint8
+
+
+def _panel():
+    """A panel with construction bypassed, for testing its pure logic."""
+    panel = fs.FrameSegmentationPanel.__new__(fs.FrameSegmentationPanel)
+    panel._prepared = OrderedDict()
+    panel._closing = False
+    return panel
+
+
+class TestMergedLabels:
+    """Merging must not collide with, or overwrite, what is already drawn."""
+
+    def test_new_labels_only_fill_the_background(self):
+        panel = _panel()
+        current = np.array([[7, 0], [0, 0]], dtype=np.uint16)
+        new = np.array([[1, 1], [2, 2]], dtype=np.uint16)
+
+        merged = panel._merged_labels(current, new)
+
+        # The existing label is untouched...
+        assert merged[0, 0] == 7
+        # ...and the incoming ones are pushed past it so nothing collides.
+        assert merged[0, 1] == 1 + 7
+        assert merged[1, 0] == 2 + 7
+        assert merged.dtype == np.uint16
+
+    def test_background_stays_background(self):
+        panel = _panel()
+        current = np.zeros((2, 2), dtype=np.uint16)
+        new = np.zeros((2, 2), dtype=np.uint16)
+        assert np.count_nonzero(panel._merged_labels(current, new)) == 0
+
+    def test_an_offset_that_would_overflow_is_refused(self):
+        """
+        Regression: the offset used to be added in the labels' own dtype.
+
+        `uint16 + python int` stays uint16 under both NEP 50 and value-based
+        casting, so a sum past 65535 wrapped round to a small number and quietly
+        aliased a new cell onto an existing one.
+        """
+
+        panel = _panel()
+        current = np.array([[65000, 0]], dtype=np.uint16)
+        new = np.array([[0, 1000]], dtype=np.uint16)
+        with pytest.raises(ValueError):
+            panel._merged_labels(current, new)
+
+
+class TestPreparedModelCache:
+    """
+    The cache holds whole networks, so it must be bounded and rarely missed.
+
+    The Cellpose diameter and thresholds are arguments to the forward pass; keying
+    the cache on them reloaded a network every time one was nudged.
+    """
+
+    def _prepared(self, model_type="cellpose"):
+        prepared = MagicMock()
+        prepared.model_type = model_type
+        prepared.config_defaults = {
+            "diameter": 30.0,
+            "cellprob_threshold": 0.0,
+            "flow_threshold": 0.4,
+        }
+        return prepared
+
+    def test_a_miss_returns_none(self):
+        panel = _panel()
+        assert panel._reuse_prepared(("m", None, None), None, None, None) is None
+
+    def test_thresholds_are_re_applied_to_a_cached_model(self):
+        panel = _panel()
+        prepared = self._prepared()
+        panel._cache_prepared(("m", None, None), prepared)
+
+        reused = panel._reuse_prepared(("m", None, None), 12.0, 0.25, 0.6)
+
+        assert reused is prepared
+        assert prepared.diameter == 12.0
+        assert prepared.cellprob_threshold == 0.25
+        assert prepared.flow_threshold == 0.6
+
+    def test_a_blank_field_restores_the_models_own_value(self):
+        panel = _panel()
+        prepared = self._prepared()
+        panel._cache_prepared(("m", None, None), prepared)
+
+        panel._reuse_prepared(("m", None, None), 12.0, 0.25, 0.6)
+        panel._reuse_prepared(("m", None, None), None, None, None)
+
+        assert prepared.diameter == 30.0
+        assert prepared.cellprob_threshold == 0.0
+        assert prepared.flow_threshold == 0.4
+
+    def test_stardist_models_are_left_alone(self):
+        panel = _panel()
+        prepared = self._prepared(model_type="stardist")
+        panel._cache_prepared(("m", None, None), prepared)
+        reused = panel._reuse_prepared(("m", None, None), 12.0, None, None)
+        assert reused is prepared
+        assert not isinstance(prepared.diameter, float)
+
+    def test_the_cache_is_bounded(self):
+        panel = _panel()
+        for i in range(fs.MAX_CACHED_MODELS + 3):
+            panel._cache_prepared((f"model-{i}", None, None), self._prepared())
+        assert len(panel._prepared) == fs.MAX_CACHED_MODELS
+
+    def test_eviction_drops_the_coldest_entry(self):
+        panel = _panel()
+        keys = [(f"model-{i}", None, None) for i in range(fs.MAX_CACHED_MODELS + 1)]
+        for key in keys[:-1]:
+            panel._cache_prepared(key, self._prepared())
+
+        # Touch the oldest so it is no longer the coldest.
+        panel._reuse_prepared(keys[0], None, None, None)
+        panel._cache_prepared(keys[-1], self._prepared())
+
+        assert keys[0] in panel._prepared
+        assert keys[1] not in panel._prepared
+
+
+class TestRecordUndo:
+    """A bulk write should be undoable, and never fatal if napari has moved on."""
+
+    def test_only_the_changed_pixels_are_recorded(self):
+        panel = _panel()
+        layer = MagicMock()
+        before = np.array([[0, 0], [1, 0]], dtype=np.uint16)
+        after = np.array([[0, 5], [1, 0]], dtype=np.uint16)
+
+        panel._record_undo(layer, 3, before, after)
+
+        (value,), _ = layer._save_history.call_args
+        indices, old, new = value
+        assert len(indices) == 3  # frame, row, column
+        np.testing.assert_array_equal(indices[0], [3])
+        np.testing.assert_array_equal(old, [0])
+        np.testing.assert_array_equal(new, [5])
+
+    def test_an_unchanged_frame_records_nothing(self):
+        panel = _panel()
+        layer = MagicMock()
+        same = np.ones((2, 2), dtype=np.uint16)
+        panel._record_undo(layer, 0, same, same.copy())
+        layer._save_history.assert_not_called()
+
+    def test_a_napari_without_the_private_history_does_not_raise(self):
+        panel = _panel()
+        layer = MagicMock()
+        layer._save_history.side_effect = AttributeError("moved in a later napari")
+        before = np.zeros((2, 2), dtype=np.uint16)
+        after = np.ones((2, 2), dtype=np.uint16)
+        panel._record_undo(layer, 0, before, after)  # must not raise
+
+
+class TestAvailableSegmentationModels:
+    """The dropdown must always build, whatever the model tree looks like."""
+
+    def test_singular_populations_are_normalised(self, monkeypatch):
+        seen = []
+
+        def fake_list(mode, return_path=False, cleanup=True):
+            seen.append((mode, cleanup))
+            return [f"{mode}-model"]
+
+        monkeypatch.setattr(
+            "celldetective.utils.model_getters.get_segmentation_models_list", fake_list
+        )
+        fs.available_segmentation_models("target")
+
+        # "segmentation_target" is not a real category directory.
+        assert [mode for mode, _ in seen] == ["targets", "generic"]
+
+    def test_listing_never_rewrites_the_model_tree(self, monkeypatch):
+        seen = []
+
+        def fake_list(mode, return_path=False, cleanup=True):
+            seen.append(cleanup)
+            return []
+
+        monkeypatch.setattr(
+            "celldetective.utils.model_getters.get_segmentation_models_list", fake_list
+        )
+        fs.available_segmentation_models("targets")
+        assert seen == [False, False]
+
+    def test_duplicates_across_families_are_dropped(self, monkeypatch):
+        monkeypatch.setattr(
+            "celldetective.utils.model_getters.get_segmentation_models_list",
+            lambda mode, return_path=False, cleanup=True: ["shared", mode],
+        )
+        models = fs.available_segmentation_models("targets")
+        assert models == ["shared", "targets", "generic"]
+
+    def test_a_placeholder_is_offered_when_listing_fails(self, monkeypatch):
+        def explode(mode, return_path=False, cleanup=True):
+            raise OSError("model repository unreachable")
+
+        monkeypatch.setattr(
+            "celldetective.utils.model_getters.get_segmentation_models_list", explode
+        )
+        assert fs.available_segmentation_models("targets") == [fs.NO_MODEL]

--- a/tests/gui/test_frame_segmentation_panel.py
+++ b/tests/gui/test_frame_segmentation_panel.py
@@ -13,7 +13,9 @@ from unittest.mock import MagicMock
 
 import numpy as np
 import pytest
+from PyQt5.QtWidgets import QVBoxLayout
 
+from celldetective.gui.base.model_channel_selection import ModelChannelSelection
 from celldetective.napari import frame_segmentation as fs
 
 
@@ -260,3 +262,69 @@ class TestAvailableSegmentationModels:
             "celldetective.utils.model_getters.get_segmentation_models_list", explode
         )
         assert fs.available_segmentation_models("targets") == [fs.NO_MODEL]
+
+
+class TestChannelRows:
+    """
+    The channel rows are the main window's, not a copy of them.
+
+    Mapping a model's inputs onto the experiment's channels is the same job here
+    as in the main window's channel dialog, and the two drifting apart is how a
+    model ends up fed a different channel depending on where it was run from.
+    """
+
+    def _panel_with_rows(self, qtbot, config, exp_channels):
+        panel = _panel()
+        panel.exp_channels = exp_channels
+        panel.config = config
+        panel.channel_selection = None
+        # A real layout, so `_build_channel_rows` is exercised as it runs in the
+        # panel; the panel itself never has to be a live QWidget for that.
+        panel.channel_layout = QVBoxLayout()
+        panel._build_channel_rows()
+        qtbot.addWidget(panel.channel_selection)
+        return panel
+
+    def test_the_rows_are_the_shared_widget(self, qtbot):
+        panel = self._panel_with_rows(
+            qtbot, {"channels": ["live_nuclei_channel"]}, ["live_nuclei_channel"]
+        )
+        assert isinstance(panel.channel_selection, ModelChannelSelection)
+        assert panel._selected_channels() == ["live_nuclei_channel"]
+
+    def test_the_stored_mapping_is_honoured(self, qtbot):
+        """
+        A model declaring channels no experiment is named after is still usable.
+
+        CP_cyto3 declares ['fluorescenceuv', 'None']; only the mapping saved by
+        the main window says which channel that slot should be fed.
+        """
+
+        panel = self._panel_with_rows(
+            qtbot,
+            {
+                "channels": ["fluorescenceuv", "None"],
+                "selected_channels": ["brightfield_channel", "None"],
+            },
+            ["brightfield_channel"],
+        )
+        assert panel._selected_channels() == ["brightfield_channel", "None"]
+
+    def test_a_mapping_of_the_wrong_shape_is_ignored(self, qtbot):
+        # `selected_channels` is read off a JSON file that nothing guarantees the
+        # shape of; a bad one must fall back rather than break the panel.
+        panel = self._panel_with_rows(
+            qtbot,
+            {"channels": ["live_nuclei_channel"], "selected_channels": "brightfield"},
+            ["live_nuclei_channel"],
+        )
+        assert panel._selected_channels() == ["live_nuclei_channel"]
+
+    def test_a_model_without_inputs_reports_no_mapping(self, qtbot):
+        panel = self._panel_with_rows(qtbot, {"channels": []}, ["brightfield_channel"])
+        assert panel._selected_channels() is None
+
+    def test_no_rows_at_all_reports_no_mapping(self):
+        panel = _panel()
+        panel.channel_selection = None
+        assert panel._selected_channels() is None

--- a/tests/gui/test_frame_segmentation_panel.py
+++ b/tests/gui/test_frame_segmentation_panel.py
@@ -111,8 +111,10 @@ class TestPreparedModelCache:
     """
     The cache holds whole networks, so it must be bounded and rarely missed.
 
-    The Cellpose diameter and thresholds are arguments to the forward pass; keying
-    the cache on them reloaded a network every time one was nudged.
+    The Cellpose thresholds are arguments to the forward pass; keying the cache
+    on them reloaded a network every time one was nudged. The diameter is not a
+    panel setting at all -- it is the size the network was trained to see -- so a
+    cached model always gets the model's own value back.
     """
 
     def _prepared(self, model_type="cellpose"):
@@ -127,27 +129,28 @@ class TestPreparedModelCache:
 
     def test_a_miss_returns_none(self):
         panel = _panel()
-        assert panel._reuse_prepared(("m", None, None), None, None, None) is None
+        assert panel._reuse_prepared(("m", None, None), None, None) is None
 
     def test_thresholds_are_re_applied_to_a_cached_model(self):
         panel = _panel()
         prepared = self._prepared()
         panel._cache_prepared(("m", None, None), prepared)
 
-        reused = panel._reuse_prepared(("m", None, None), 12.0, 0.25, 0.6)
+        reused = panel._reuse_prepared(("m", None, None), 0.25, 0.6)
 
         assert reused is prepared
-        assert prepared.diameter == 12.0
         assert prepared.cellprob_threshold == 0.25
         assert prepared.flow_threshold == 0.6
+        # Not a panel setting: the frame is rescaled to the trained size instead.
+        assert prepared.diameter == 30.0
 
     def test_a_blank_field_restores_the_models_own_value(self):
         panel = _panel()
         prepared = self._prepared()
         panel._cache_prepared(("m", None, None), prepared)
 
-        panel._reuse_prepared(("m", None, None), 12.0, 0.25, 0.6)
-        panel._reuse_prepared(("m", None, None), None, None, None)
+        panel._reuse_prepared(("m", None, None), 0.25, 0.6)
+        panel._reuse_prepared(("m", None, None), None, None)
 
         assert prepared.diameter == 30.0
         assert prepared.cellprob_threshold == 0.0
@@ -157,7 +160,7 @@ class TestPreparedModelCache:
         panel = _panel()
         prepared = self._prepared(model_type="stardist")
         panel._cache_prepared(("m", None, None), prepared)
-        reused = panel._reuse_prepared(("m", None, None), 12.0, None, None)
+        reused = panel._reuse_prepared(("m", None, None), 0.25, None)
         assert reused is prepared
         assert not isinstance(prepared.diameter, float)
 
@@ -174,7 +177,7 @@ class TestPreparedModelCache:
             panel._cache_prepared(key, self._prepared())
 
         # Touch the oldest so it is no longer the coldest.
-        panel._reuse_prepared(keys[0], None, None, None)
+        panel._reuse_prepared(keys[0], None, None)
         panel._cache_prepared(keys[-1], self._prepared())
 
         assert keys[0] in panel._prepared
@@ -328,3 +331,137 @@ class TestChannelRows:
         panel = _panel()
         panel.channel_selection = None
         assert panel._selected_channels() is None
+
+
+class TestTrainedCellSize:
+    """
+    The cell size is the only handle on rescaling, and every Cellpose model has
+    one whether or not it says so in microns.
+
+    A model is trained to see objects at a fixed pixel size, and the frame is
+    rescaled so they arrive at it. Models built through celldetective record the
+    physical size as ``cell_size_um``; a generic Cellpose model does not, but
+    records the same thing as ``diameter`` px at its own ``spatial_calibration``.
+    Without the second reading, a generic model could not be rescaled at all --
+    the correction needs the trained size and the target, and one was missing.
+    """
+
+    def _panel(self, config):
+        panel = _panel()
+        panel.config = config
+        return panel
+
+    def test_a_declared_cell_size_is_used_as_is(self):
+        panel = self._panel({"model_type": "cellpose", "cell_size_um": 9.211})
+        assert panel._trained_cell_size_um() == 9.211
+
+    def test_a_generic_cellpose_model_derives_it_from_the_diameter(self):
+        panel = self._panel(
+            {"model_type": "cellpose", "diameter": 30.0, "spatial_calibration": 0.5}
+        )
+        assert panel._trained_cell_size_um() == pytest.approx(15.0)
+
+    def test_a_declared_size_wins_over_the_derivation(self):
+        panel = self._panel(
+            {
+                "model_type": "cellpose",
+                "cell_size_um": 9.211,
+                "diameter": 30.0,
+                "spatial_calibration": 0.5,
+            }
+        )
+        assert panel._trained_cell_size_um() == 9.211
+
+    def test_a_generic_stardist_model_has_none(self):
+        # StarDist has no diameter to read a size off, so there is nothing to
+        # rescale against and the row is not offered.
+        panel = self._panel({"model_type": "stardist", "spatial_calibration": 0.31})
+        assert panel._trained_cell_size_um() is None
+
+    @pytest.mark.parametrize(
+        "config",
+        [
+            {"model_type": "cellpose", "diameter": 30.0},
+            {"model_type": "cellpose", "spatial_calibration": 0.5},
+            {"model_type": "cellpose", "diameter": 0, "spatial_calibration": 0.5},
+            {"model_type": "cellpose", "diameter": 30.0, "spatial_calibration": 0},
+            {"model_type": "cellpose", "cell_size_um": 0},
+        ],
+    )
+    def test_a_size_that_cannot_be_worked_out_is_none(self, config):
+        assert self._panel(config)._trained_cell_size_um() is None
+
+    def test_no_config_reports_none(self):
+        assert self._panel(None)._trained_cell_size_um() is None
+
+
+class TestParameterRows:
+    """The panel offers only the parameters a run should actually vary."""
+
+    def _rows(self, qtbot, config):
+        from PyQt5.QtWidgets import QFormLayout, QWidget
+
+        panel = _panel()
+        panel.config = config
+        panel.diameter_le = None
+        panel.cellprob_le = None
+        panel.flow_le = None
+        panel.cell_size_le = None
+        # Parented to the panel object so the layout and its fields outlive this
+        # helper: Qt deletes the C++ widgets as soon as the last holder goes.
+        holder = QWidget()
+        qtbot.addWidget(holder)
+        panel._holder = holder
+        panel.param_form = QFormLayout(holder)
+        panel._build_parameter_rows()
+        labels = [
+            panel.param_form.itemAt(i, QFormLayout.LabelRole).widget().text()
+            for i in range(panel.param_form.rowCount())
+            if panel.param_form.itemAt(i, QFormLayout.LabelRole) is not None
+        ]
+        return panel, labels
+
+    def test_a_generic_cellpose_model_offers_a_cell_size(self, qtbot):
+        panel, labels = self._rows(
+            qtbot,
+            {"model_type": "cellpose", "diameter": 30.0, "spatial_calibration": 0.5},
+        )
+        assert any("cell size" in text for text in labels)
+        assert panel.cell_size_le is not None
+        assert panel.cell_size_le.value() == pytest.approx(15.0)
+
+    def test_the_diameter_is_never_offered(self, qtbot):
+        """
+        It is the size the network was trained to see, not a setting: a model
+        trained on 30 px objects should keep being asked for 30 px ones, and the
+        frame rescaled until that is what it gets.
+        """
+        _, labels = self._rows(
+            qtbot,
+            {
+                "model_type": "cellpose",
+                "diameter": 30.0,
+                "spatial_calibration": 0.5,
+                "cellprob_threshold": 0.0,
+                "flow_threshold": 0.4,
+            },
+        )
+        assert not any("diameter" in text.lower() for text in labels)
+        assert any("cell probability" in text for text in labels)
+        assert any("flow threshold" in text for text in labels)
+
+    def test_a_stored_target_seeds_the_field(self, qtbot):
+        panel, _ = self._rows(
+            qtbot,
+            {
+                "model_type": "cellpose",
+                "cell_size_um": 10.0,
+                "target_cell_size_um": 25.0,
+            },
+        )
+        assert panel.cell_size_le.value() == pytest.approx(25.0)
+
+    def test_a_model_with_nothing_to_tune_says_so(self, qtbot):
+        panel, labels = self._rows(qtbot, {"model_type": "stardist"})
+        assert panel.cell_size_le is None
+        assert panel.param_form.rowCount() == 1

--- a/tests/gui/test_model_channel_selection.py
+++ b/tests/gui/test_model_channel_selection.py
@@ -1,0 +1,162 @@
+"""
+Unit tests for the shared model channel-selection widget.
+
+The widget maps a model's declared input slots onto the experiment's own
+channels, and is used both by the main window's channel dialog and by the napari
+single-frame panel. What is pinned here is the seeding order -- stored mapping,
+then name match, then None -- because that is what decides which channel a model
+is actually fed when nobody touches the dropdowns.
+"""
+
+import logging
+
+import pytest
+from PyQt5.QtWidgets import QLabel
+
+from celldetective.gui.base.model_channel_selection import (
+    NO_CHANNEL,
+    ModelChannelSelection,
+)
+
+
+@pytest.fixture(autouse=True)
+def disable_logging():
+    """Disable all logging to avoid Windows OSError with pytest capture."""
+    logging.disable(logging.CRITICAL)
+    yield
+    logging.disable(logging.NOTSET)
+
+
+EXP_CHANNELS = ["brightfield_channel", "live_nuclei_channel", "dead_nuclei_channel"]
+
+
+def _widget(qtbot, required, selected=None, available=None, **kwargs):
+    """Build a widget and hand it to qtbot so it is destroyed with the test."""
+    widget = ModelChannelSelection(
+        required_channels=required,
+        available_channels=EXP_CHANNELS if available is None else available,
+        selected_channels=selected,
+        **kwargs,
+    )
+    qtbot.addWidget(widget)
+    return widget
+
+
+class TestRows:
+    """One dropdown per input slot, offering every channel plus None."""
+
+    def test_one_dropdown_per_slot(self, qtbot):
+        widget = _widget(qtbot, ["brightfield_channel", "live_nuclei_channel"])
+        assert len(widget.channel_cbs) == 2
+
+    def test_every_channel_is_offered_plus_none(self, qtbot):
+        widget = _widget(qtbot, ["brightfield_channel"])
+        combo = widget.channel_cbs[0]
+        offered = [combo.itemText(i) for i in range(combo.count())]
+        assert offered == EXP_CHANNELS + [NO_CHANNEL]
+
+    def test_a_model_without_inputs_builds_anyway(self, qtbot):
+        widget = _widget(qtbot, [])
+        assert widget.channel_cbs == []
+        assert widget.selected_channels() == []
+
+    def test_an_experiment_without_channels_still_offers_none(self, qtbot):
+        widget = _widget(qtbot, ["brightfield_channel"], available=[])
+        assert widget.selected_channels() == [NO_CHANNEL]
+
+
+class TestSeeding:
+    """
+    The stored mapping wins, then a name match, then None.
+
+    Models such as CP_cyto3 declare channel names no real experiment uses; without
+    the stored mapping every slot would open on None and the model could not be
+    run at all.
+    """
+
+    def test_a_slot_named_after_a_channel_opens_on_it(self, qtbot):
+        widget = _widget(qtbot, ["live_nuclei_channel"])
+        assert widget.selected_channels() == ["live_nuclei_channel"]
+
+    def test_an_unknown_slot_opens_on_none(self, qtbot):
+        widget = _widget(qtbot, ["fluorescenceuv"])
+        assert widget.selected_channels() == [NO_CHANNEL]
+
+    def test_the_stored_mapping_is_preferred(self, qtbot):
+        widget = _widget(
+            qtbot,
+            ["fluorescenceuv", "None"],
+            selected=["dead_nuclei_channel", NO_CHANNEL],
+        )
+        assert widget.selected_channels() == ["dead_nuclei_channel", NO_CHANNEL]
+
+    def test_the_stored_mapping_overrides_a_name_match(self, qtbot):
+        widget = _widget(
+            qtbot, ["live_nuclei_channel"], selected=["brightfield_channel"]
+        )
+        assert widget.selected_channels() == ["brightfield_channel"]
+
+    def test_a_stale_entry_falls_back_slot_by_slot(self, qtbot):
+        # The first entry names a channel this experiment does not have, so that
+        # slot falls back to its own name match; the second is honoured.
+        widget = _widget(
+            qtbot,
+            ["live_nuclei_channel", "brightfield_channel"],
+            selected=["gone_channel", "dead_nuclei_channel"],
+        )
+        assert widget.selected_channels() == [
+            "live_nuclei_channel",
+            "dead_nuclei_channel",
+        ]
+
+    def test_a_short_mapping_leaves_the_remaining_slots_to_the_name_match(self, qtbot):
+        widget = _widget(
+            qtbot,
+            ["fluorescenceuv", "live_nuclei_channel"],
+            selected=["brightfield_channel"],
+        )
+        assert widget.selected_channels() == [
+            "brightfield_channel",
+            "live_nuclei_channel",
+        ]
+
+
+class TestReporting:
+    """What the widget reports back, and what the caller does with it."""
+
+    def test_selected_channels_follows_the_dropdowns(self, qtbot):
+        widget = _widget(qtbot, ["brightfield_channel"])
+        widget.channel_cbs[0].setCurrentIndex(
+            widget.channel_cbs[0].findText("dead_nuclei_channel")
+        )
+        assert widget.selected_channels() == ["dead_nuclei_channel"]
+
+    def test_is_empty_when_every_slot_is_none(self, qtbot):
+        widget = _widget(qtbot, ["fluorescenceuv", "fluorescenceir"])
+        assert widget.is_empty()
+
+    def test_is_not_empty_when_one_slot_is_fed(self, qtbot):
+        widget = _widget(qtbot, ["fluorescenceuv", "live_nuclei_channel"])
+        assert not widget.is_empty()
+
+    def test_a_model_without_inputs_is_not_reported_as_empty(self, qtbot):
+        # Nothing to assign is not the same as everything left unassigned: the
+        # caller must not refuse to run such a model.
+        widget = _widget(qtbot, [])
+        assert not widget.is_empty()
+
+
+class TestPresentation:
+    """The requirement label is optional, the dropdowns are not."""
+
+    def _labels(self, widget):
+        return [label.text() for label in widget.findChildren(QLabel)]
+
+    def test_the_slot_the_dropdown_feeds_is_printed(self, qtbot):
+        widget = _widget(qtbot, ["fluorescenceuv"])
+        assert "Req: fluorescenceuv" in self._labels(widget)
+
+    def test_the_requirement_can_be_hidden(self, qtbot):
+        widget = _widget(qtbot, ["fluorescenceuv"], show_requirement=False)
+        assert "Req: fluorescenceuv" not in self._labels(widget)
+        assert len(widget.channel_cbs) == 1

--- a/tests/gui/test_segmentation_model_params.py
+++ b/tests/gui/test_segmentation_model_params.py
@@ -20,3 +20,94 @@ def test_seg_model_params_widget_abort_on_missing_model(qtbot):
         assert "NON_EXISTENT_MODEL_NAME could not be located or loaded" in str(excinfo.value)
         # Verify that QMessageBox.exec was indeed called to alert the user
         mock_exec.assert_called_once()
+
+
+class TestCellSizeRow:
+    """
+    The cell size is what a model is rescaled against, so every model that has
+    a trained size must offer it -- including a generic Cellpose model, which
+    records that size in pixels rather than in microns.
+
+    The row is also what decides whether a cell size is saved at all. It used to
+    be built for every model and merely hidden for those without one, so
+    ``set_selected_channels_for_segmentation`` -- which tests for the field --
+    wrote its placeholder 40 um as though the user had asked for it.
+    """
+
+    def _widget(self, qtbot, config, monkeypatch, exp_channels=("brightfield_channel",)):
+        from celldetective.gui.settings import _segmentation_model_params as smp
+
+        monkeypatch.setattr(smp.SegModelParamsWidget, "locate_model_path", lambda s: None)
+
+        parent = MagicMock()
+        parent.parent_window.locate_image = MagicMock()
+        parent.parent_window.exp_channels = list(exp_channels)
+
+        widget = SegModelParamsWidget.__new__(SegModelParamsWidget)
+        # Built by hand rather than through __init__: the real constructor reads a
+        # model off disk, and what is under test is only how the config is read.
+        super(SegModelParamsWidget, widget).__init__()
+        widget.parent_window = parent
+        widget.attr_parent = parent.parent_window
+        widget.input_config = config
+        widget.required_channels = config.get("channels", [])
+        widget.model_name = "test-model"
+        from PyQt5.QtGui import QDoubleValidator
+        from PyQt5.QtWidgets import QVBoxLayout
+
+        widget.onlyFloat = QDoubleValidator()
+        widget.layout = QVBoxLayout()
+        widget.populate_widgets()
+        widget.setLayout(widget.layout)
+        qtbot.addWidget(widget)
+        return widget
+
+    def test_a_declared_cell_size_is_offered(self, qtbot, monkeypatch):
+        widget = self._widget(
+            qtbot,
+            {"channels": ["brightfield_channel"], "cell_size_um": 9.211},
+            monkeypatch,
+        )
+        assert hasattr(widget, "diameter_le")
+        assert float(widget.diameter_le.get_threshold()) == pytest.approx(9.211)
+
+    def test_a_generic_cellpose_model_is_offered_one_too(self, qtbot, monkeypatch):
+        """Derived from the pixel diameter it was trained on: 30 px x 0.5 um/px."""
+        widget = self._widget(
+            qtbot,
+            {
+                "channels": ["brightfield_channel"],
+                "model_type": "cellpose",
+                "diameter": 30.0,
+                "spatial_calibration": 0.5,
+            },
+            monkeypatch,
+        )
+        assert hasattr(widget, "diameter_le")
+        assert float(widget.diameter_le.get_threshold()) == pytest.approx(15.0)
+
+    def test_the_row_reopens_on_the_size_last_saved(self, qtbot, monkeypatch):
+        widget = self._widget(
+            qtbot,
+            {
+                "channels": ["brightfield_channel"],
+                "cell_size_um": 9.211,
+                "target_cell_size_um": 25.0,
+            },
+            monkeypatch,
+        )
+        assert float(widget.diameter_le.get_threshold()) == pytest.approx(25.0)
+
+    def test_a_model_without_a_trained_size_has_no_field_to_save(
+        self, qtbot, monkeypatch
+    ):
+        """
+        No field means no cell size is written when the dialog is applied, rather
+        than a placeholder nobody entered being saved and rescaling later runs.
+        """
+        widget = self._widget(
+            qtbot,
+            {"channels": ["brightfield_channel"], "model_type": "stardist"},
+            monkeypatch,
+        )
+        assert not hasattr(widget, "diameter_le")

--- a/tests/gui/test_thresholds_gui.py
+++ b/tests/gui/test_thresholds_gui.py
@@ -118,6 +118,15 @@ def app_with_project(qtbot, ensure_experiment_test):
         lambda: getattr(test_app, "control_panel", None) is not None, timeout=15000
     )
 
+    # Give the control panel a window tall enough to lay its contents out. The
+    # offscreen platform reports a small screen, so the panel opens at 440x550
+    # and the layout resolves the overflow by squeezing widgets to zero height.
+    # A zero-height button is still `isVisible()`, but its rect has no interior,
+    # so `QTest.mouseClick` on its centre delivers nothing and the signal never
+    # fires -- a click that misses in silence rather than an error.
+    test_app.control_panel.resize(600, 1000)
+    QApplication.processEvents()
+
     yield test_app
 
     # Cleanup - close the app first (triggers thread cleanup in closeEvent)
@@ -162,7 +171,14 @@ def wizard_from_app(qtbot, app_with_project):
     # Open the segmentation model loader (upload_segmentation_model creates
     # panel.seg_model_loader synchronously). Wait for the button to be hittable,
     # then for the attribute to appear, rather than sleeping a fixed amount.
-    qtbot.waitUntil(lambda: panel.upload_model_btn.isVisible(), timeout=5000)
+    # `isVisible()` is not enough to know a click will land: a widget squeezed
+    # to zero height by its layout reports visible while having nothing to hit.
+    # Wait for real geometry instead.
+    qtbot.waitUntil(
+        lambda: panel.upload_model_btn.height() > 0
+        and not panel.upload_model_btn.visibleRegion().isEmpty(),
+        timeout=5000,
+    )
     qtbot.mouseClick(panel.upload_model_btn, QtCore.Qt.LeftButton)
     qtbot.waitUntil(
         lambda: getattr(panel, "seg_model_loader", None) is not None, timeout=5000

--- a/tests/gui/test_viewers.py
+++ b/tests/gui/test_viewers.py
@@ -114,7 +114,13 @@ class TestChannelOffsetViewer:
             parent_window=mock_parent_window,
         )
         qtbot.addWidget(viewer)
-        viewer.show()
+        # Deliberately not shown. These assertions only read state the
+        # constructor set, so showing adds no coverage -- but it puts a real
+        # top-level window in front of pytest-qt's forced processEvents(), and
+        # on the Windows CI runner that combination faults inside Qt's own
+        # event dispatch (access violation, no Python frame, first test of the
+        # file). test_base_viewer.py still exercises show() on this same base
+        # class on the same runners.
 
         assert viewer.n_channels == 2
         assert viewer.channel_names == ["Ch1", "Ch2"]
@@ -190,7 +196,13 @@ class TestContourViewer:
             stack=dummy_labels_3d, labels=dummy_labels_3d, initial_edge=5
         )
         qtbot.addWidget(viewer)
-        viewer.show()
+        # Deliberately not shown. These assertions only read state the
+        # constructor set, so showing adds no coverage -- but it puts a real
+        # top-level window in front of pytest-qt's forced processEvents(), and
+        # on the Windows CI runner that combination faults inside Qt's own
+        # event dispatch (access violation, no Python frame, first test of the
+        # file). test_base_viewer.py still exercises show() on this same base
+        # class on the same runners.
 
         assert viewer.edge_size == 5
         assert hasattr(viewer, "im_mask")
@@ -247,7 +259,13 @@ class TestSizeViewer:
 
         viewer = CellSizeViewer(stack=dummy_stack, initial_diameter=20)
         qtbot.addWidget(viewer)
-        viewer.show()
+        # Deliberately not shown. These assertions only read state the
+        # constructor set, so showing adds no coverage -- but it puts a real
+        # top-level window in front of pytest-qt's forced processEvents(), and
+        # on the Windows CI runner that combination faults inside Qt's own
+        # event dispatch (access violation, no Python frame, first test of the
+        # file). test_base_viewer.py still exercises show() on this same base
+        # class on the same runners.
 
         assert viewer.diameter == 20
         assert hasattr(viewer, "circ")
@@ -301,7 +319,13 @@ class TestThresholdViewer:
             stack=dummy_stack_4d, initial_threshold=10.0
         )
         qtbot.addWidget(viewer)
-        viewer.show()
+        # Deliberately not shown. These assertions only read state the
+        # constructor set, so showing adds no coverage -- but it puts a real
+        # top-level window in front of pytest-qt's forced processEvents(), and
+        # on the Windows CI runner that combination faults inside Qt's own
+        # event dispatch (access violation, no Python frame, first test of the
+        # file). test_base_viewer.py still exercises show() on this same base
+        # class on the same runners.
 
         assert viewer.thresh == 10.0
         assert hasattr(viewer, "mask")

--- a/tests/run_gui_tests.py
+++ b/tests/run_gui_tests.py
@@ -1,0 +1,65 @@
+"""
+Run the GUI tests one file per process.
+
+Qt state accumulates across tests in a way no fixture fully undoes: widgets are
+closed but deleted later, their children's queued events outlive them, and
+`QTest.qWait` / `processEvents` in a later test is what finally dispatches the
+backlog. When that dispatch reaches an object Qt has already freed, the result
+is a `Windows fatal exception: access violation` -- the interpreter dies with no
+traceback and no failing assertion, taking the whole run's results with it,
+attributed to whichever test happened to be on the stack.
+
+The individual hazards are worth fixing and are being fixed. The accumulation is
+what turns any one of them into a dead process, and a process boundary per file
+removes it: each file starts with an empty event queue and no leftover widgets,
+and a file that does crash reports as that file failing instead of truncating
+everything after it.
+
+Usage
+-----
+    python tests/run_gui_tests.py [pytest args...]
+
+Exits non-zero if any file fails, after running all of them, so one bad file
+does not hide the state of the rest.
+"""
+
+import subprocess
+import sys
+from pathlib import Path
+
+GUI_TESTS = Path(__file__).parent / "gui"
+
+
+def main(argv):
+    files = sorted(p for p in GUI_TESTS.glob("test_*.py"))
+    if not files:
+        print(f"No GUI test files found under {GUI_TESTS}", file=sys.stderr)
+        return 1
+
+    failed = []
+    for path in files:
+        rel = path.relative_to(Path.cwd()) if path.is_relative_to(Path.cwd()) else path
+        print(f"\n=== {rel} ===", flush=True)
+        result = subprocess.run(
+            [sys.executable, "-m", "pytest", str(path), *argv],
+            check=False,
+        )
+        # A native crash shows up as a negative code (signal) or as Windows'
+        # 0xC0000005; either way the file did not pass and the message needs to
+        # say so rather than let the run look clean.
+        if result.returncode != 0:
+            failed.append((rel, result.returncode))
+
+    print("\n" + "=" * 70)
+    if failed:
+        print(f"{len(failed)} of {len(files)} GUI test files failed:")
+        for rel, code in failed:
+            print(f"  {rel} (exit {code})")
+        return 1
+
+    print(f"All {len(files)} GUI test files passed.")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main(sys.argv[1:]))

--- a/tests/run_gui_tests.py
+++ b/tests/run_gui_tests.py
@@ -34,7 +34,10 @@ VERBOSITY_FLAGS = ("-v", "-vv", "-q", "-qq", "--verbose", "--quiet")
 
 
 def main(argv):
-    files = sorted(p for p in GUI_TESTS.glob("test_*.py"))
+    # `rglob`, not `glob`: this replaced `pytest tests/gui/`, which collected
+    # subdirectories too. A plain `glob` would drop e.g. `table_ops/` silently,
+    # leaving those tests unrun on every job with nothing in the log to say so.
+    files = sorted(p for p in GUI_TESTS.rglob("test_*.py"))
     if not files:
         print(f"No GUI test files found under {GUI_TESTS}", file=sys.stderr)
         return 1

--- a/tests/run_gui_tests.py
+++ b/tests/run_gui_tests.py
@@ -23,11 +23,14 @@ Exits non-zero if any file fails, after running all of them, so one bad file
 does not hide the state of the rest.
 """
 
+import os
 import subprocess
 import sys
 from pathlib import Path
 
 GUI_TESTS = Path(__file__).parent / "gui"
+
+VERBOSITY_FLAGS = ("-v", "-vv", "-q", "-qq", "--verbose", "--quiet")
 
 
 def main(argv):
@@ -36,6 +39,15 @@ def main(argv):
         print(f"No GUI test files found under {GUI_TESTS}", file=sys.stderr)
         return 1
 
+    # A native crash kills the child before pytest can write its summary, so the
+    # only record of where it happened is whatever already reached the log.
+    # Default to one line per test and turn off block buffering on the child's
+    # stdout, so the last line printed names the test that died instead of
+    # leaving a file-sized haystack.
+    if not any(a in VERBOSITY_FLAGS for a in argv):
+        argv = ["-v", *argv]
+    env = {**os.environ, "PYTHONUNBUFFERED": "1"}
+
     failed = []
     for path in files:
         rel = path.relative_to(Path.cwd()) if path.is_relative_to(Path.cwd()) else path
@@ -43,6 +55,7 @@ def main(argv):
         result = subprocess.run(
             [sys.executable, "-m", "pytest", str(path), *argv],
             check=False,
+            env=env,
         )
         # A native crash shows up as a negative code (signal) or as Windows'
         # 0xC0000005; either way the file did not pass and the message needs to

--- a/tests/test_partial_install.py
+++ b/tests/test_partial_install.py
@@ -1,7 +1,46 @@
+"""
+The package must import and fail gracefully when the optional extras are absent.
+
+Every test here reloads a module with its heavy dependency mocked away, which
+re-executes it and rebinds every class and function it defines. Any module
+reloaded inside a test is therefore reloaded again on the way out, with the real
+dependencies back in ``sys.modules``: without that, later tests in the run would
+be talking to a module that was built while TensorFlow, Torch, StarDist and
+Cellpose all looked missing, and any object they had already imported by name
+would belong to the previous incarnation of it.
+"""
+
 import unittest
-from unittest.mock import MagicMock, patch
+from unittest.mock import patch
 import sys
 import importlib
+from contextlib import contextmanager
+
+
+@contextmanager
+def _reloaded_without(module, missing):
+    """
+    Reload `module` with `missing` mocked out, then reload it again to restore it.
+
+    Parameters
+    ----------
+    module : module
+        The module to reload.
+    missing : dict
+        ``sys.modules`` entries to override for the duration, mapped to None to
+        make importing them fail.
+
+    Yields
+    ------
+    module
+        The module, reloaded in the degraded environment.
+    """
+
+    try:
+        with patch.dict(sys.modules, missing):
+            yield importlib.reload(module)
+    finally:
+        importlib.reload(module)
 
 
 class TestPartialValidation(unittest.TestCase):
@@ -11,57 +50,72 @@ class TestPartialValidation(unittest.TestCase):
         # This test assumes the environment MIGHT have them, so we must mock them as missing
         # to ensure the code handles it.
 
-        with patch.dict(
-            sys.modules,
-            {
-                "tensorflow": None,
-                "torch": None,
-                "stardist": None,
-                "cellpose": None,
-                "cellpose.models": None,
-                "stardist.models": None,
-            },
-        ):
-            # Force reload of celldetective.segmentation to test its imports
-            try:
-                import celldetective.segmentation
+        import celldetective.segmentation
 
-                importlib.reload(celldetective.segmentation)
-            except ImportError as e:
-                self.fail(
-                    f"Could not import celldetective.segmentation without extras: {e}"
-                )
-            except Exception as e:
-                self.fail(f"Unexpected error importing celldetective.segmentation: {e}")
+        missing = {
+            "tensorflow": None,
+            "torch": None,
+            "stardist": None,
+            "cellpose": None,
+            "cellpose.models": None,
+            "stardist.models": None,
+        }
+        try:
+            with _reloaded_without(celldetective.segmentation, missing):
+                pass
+        except ImportError as e:
+            self.fail(
+                f"Could not import celldetective.segmentation without extras: {e}"
+            )
+        except Exception as e:
+            self.fail(f"Unexpected error importing celldetective.segmentation: {e}")
+
+    def test_reloading_does_not_leave_the_module_degraded(self):
+        """
+        The suite must be handed back a module built with the real extras present.
+
+        `tests.test_segment_frame` asserts on classes from
+        `celldetective.segmentation`; if the reload above were the last one, those
+        classes would be the ones defined while every extra looked missing, and
+        would no longer be the ones the module hands out.
+        """
+
+        import celldetective.segmentation as seg
+
+        before = seg.PreparedSegmentationModel
+        with _reloaded_without(seg, {"tensorflow": None, "stardist": None}) as during:
+            self.assertIsNot(during.PreparedSegmentationModel, before)
+
+        prepared = seg.prepare_segmentation_model("a-model-that-does-not-exist")
+        self.assertIsNone(prepared)
+        self.assertIs(
+            seg.PreparedSegmentationModel,
+            sys.modules["celldetective.segmentation"].PreparedSegmentationModel,
+        )
 
     def test_graceful_failure_stardist(self):
         """Test that calling stardist functions raises RuntimeError if missing."""
-        with patch.dict(sys.modules, {"stardist": None, "stardist.models": None}):
-            # We need to reload the util module to pick up the missing module
-            import celldetective.utils.stardist_utils
+        import celldetective.utils.stardist_utils
 
-            importlib.reload(celldetective.utils.stardist_utils)
-
-            from celldetective.utils.stardist_utils import _prep_stardist_model
-
+        with _reloaded_without(
+            celldetective.utils.stardist_utils,
+            {"stardist": None, "stardist.models": None},
+        ) as stardist_utils:
             with self.assertRaises(RuntimeError) as cm:
-                _prep_stardist_model("fake_model", "fake_path")
+                stardist_utils._prep_stardist_model("fake_model", "fake_path")
 
             self.assertIn("StarDist is not installed", str(cm.exception))
 
     def test_graceful_failure_cellpose(self):
         """Test that calling cellpose functions raises RuntimeError if missing."""
-        with patch.dict(
-            sys.modules, {"cellpose": None, "cellpose.models": None, "torch": None}
-        ):
-            import celldetective.utils.cellpose_utils
+        import celldetective.utils.cellpose_utils
 
-            importlib.reload(celldetective.utils.cellpose_utils)
-
-            from celldetective.utils.cellpose_utils import _prep_cellpose_model
-
+        with _reloaded_without(
+            celldetective.utils.cellpose_utils,
+            {"cellpose": None, "cellpose.models": None, "torch": None},
+        ) as cellpose_utils:
             with self.assertRaises(RuntimeError) as cm:
-                _prep_cellpose_model("fake_model", "fake_path")
+                cellpose_utils._prep_cellpose_model("fake_model", "fake_path")
 
             # Message check might correspond to torch or cellpose depending on which import hits first
             # Our code checks torch first.

--- a/tests/test_segment_frame.py
+++ b/tests/test_segment_frame.py
@@ -171,7 +171,8 @@ class TestChannelMappingAndParameters(unittest.TestCase):
 
     ``segment()`` used to ignore ``selected_channels`` and ``target_cell_size_um``
     while ``SegmentCellDLProcess`` honoured both, so the library and the pipeline
-    produced different masks for the same model. These pin the aligned behaviour.
+    produced different masks for the same model. These pin the aligned behaviour,
+    which the stored configuration reaches only through ``use_stored_mapping``.
     """
 
     @classmethod
@@ -413,8 +414,8 @@ class TestSegmentHonoursTheStoredConfiguration(unittest.TestCase):
             labels[0], segmentation.segment_frame(self.stack[0], prepared)
         )
 
-    def test_stored_selected_channels_are_honoured(self):
-        """A mapping written into config_input.json reaches the prepared model."""
+    def test_stored_selected_channels_are_opt_in(self):
+        """A mapping written into config_input.json is used only when asked for."""
 
         model_path = segmentation.locate_segmentation_model(MODEL)
         config_path = os.path.join(model_path, "config_input.json")
@@ -428,11 +429,25 @@ class TestSegmentHonoursTheStoredConfiguration(unittest.TestCase):
             with open(config_path, "w") as config_file:
                 json.dump(config, config_file)
 
+            # config_input.json is installed once and shared by every experiment,
+            # so a mapping saved in the GUI must not silently reach a library call.
+            ignored = segmentation.prepare_segmentation_model(
+                MODEL,
+                channels=self.channels,
+                spatial_calibration=self.spatial_calibration,
+                use_gpu=False,
+            )
+            self.assertEqual(
+                list(ignored.required_channels), list(config["channels"])
+            )
+
+            # Opting in gets the pipeline's behaviour...
             prepared = segmentation.prepare_segmentation_model(
                 MODEL,
                 channels=self.channels,
                 spatial_calibration=self.spatial_calibration,
                 use_gpu=False,
+                use_stored_mapping=True,
             )
             self.assertEqual(list(prepared.required_channels), mapping)
 
@@ -442,6 +457,7 @@ class TestSegmentHonoursTheStoredConfiguration(unittest.TestCase):
                 channels=self.channels,
                 spatial_calibration=self.spatial_calibration,
                 use_gpu=False,
+                use_stored_mapping=True,
                 selected_channels=list(config["channels"]),
             )
             self.assertEqual(

--- a/tests/test_segment_frame.py
+++ b/tests/test_segment_frame.py
@@ -6,6 +6,13 @@ once) and :func:`segment_frame` (run it on one image), so that the napari viewer
 can segment the frame on screen without rebuilding the model. These tests pin
 the property that makes the split safe: composing the two halves must reproduce
 exactly what ``segment()`` returns for the same stack.
+
+Everything is reached through the ``segmentation`` module rather than bound at
+import time. ``tests.test_partial_install`` reloads that module to check it
+survives missing extras, which rebinds every class and function in it; a name
+captured up here would then belong to the previous incarnation of the module,
+and an ``isinstance`` check against it would fail against objects the reloaded
+module builds.
 """
 
 import json
@@ -15,12 +22,7 @@ import unittest
 import numpy as np
 from tifffile import imread
 
-from celldetective.segmentation import (
-    PreparedSegmentationModel,
-    prepare_segmentation_model,
-    segment,
-    segment_frame,
-)
+import celldetective.segmentation as segmentation
 
 TEST_IMAGE_FILENAME = os.path.join(
     os.path.dirname(__file__), os.sep.join(["assets", "sample.tif"])
@@ -30,6 +32,33 @@ TEST_CONFIG_FILENAME = os.path.join(
 )
 
 MODEL = "mcf7_nuc_multimodal"
+CELLPOSE_MODEL = "CP_cyto3"
+
+
+def _model_config(model_name):
+    """Read a model's ``config_input.json``, downloading the model if need be."""
+    model_path = segmentation.locate_segmentation_model(model_name)
+    with open(os.path.join(model_path, "config_input.json")) as config_file:
+        return json.load(config_file)
+
+
+def _requires_cellpose():
+    """
+    Skip when Cellpose cannot actually run here.
+
+    Loading a real Cellpose model is the only way to cover the Windows path bug,
+    but it is also the only test in the suite that genuinely initialises Torch --
+    so a broken Torch install (the Windows CI runners currently fail to load
+    ``c10.dll``) would turn these into failures about the environment rather than
+    about the code.
+    """
+
+    try:
+        import torch  # noqa: F401
+        from cellpose.models import CellposeModel  # noqa: F401
+    except Exception as e:
+        return unittest.skip(f"Cellpose/Torch unavailable: {e}")
+    return lambda cls: cls
 
 
 class TestSegmentFrameMatchesSegment(unittest.TestCase):
@@ -45,7 +74,7 @@ class TestSegmentFrameMatchesSegment(unittest.TestCase):
         cls.channels = config["channels"]
         cls.spatial_calibration = config["spatial_calibration"]
 
-        cls.reference = segment(
+        cls.reference = segmentation.segment(
             cls.stack,
             MODEL,
             channels=cls.channels,
@@ -55,7 +84,7 @@ class TestSegmentFrameMatchesSegment(unittest.TestCase):
         )
 
     def _prepare(self):
-        return prepare_segmentation_model(
+        return segmentation.prepare_segmentation_model(
             MODEL,
             channels=self.channels,
             spatial_calibration=self.spatial_calibration,
@@ -64,12 +93,15 @@ class TestSegmentFrameMatchesSegment(unittest.TestCase):
 
     def test_prepare_returns_a_usable_model(self):
         prepared = self._prepare()
-        self.assertIsInstance(prepared, PreparedSegmentationModel)
+        self.assertIsInstance(prepared, segmentation.PreparedSegmentationModel)
         self.assertIsNotNone(prepared.model)
         self.assertIn(prepared.model_type, ("stardist", "cellpose"))
         self.assertEqual(list(prepared.channels), list(self.channels))
-        # Every channel the model needs is accounted for, either transferred or
-        # explicitly zeroed.
+        # One resolution per model input slot, and every slot accounted for:
+        # either it has a source channel or it is explicitly zeroed.
+        self.assertEqual(
+            len(prepared.channel_indices), len(prepared.required_channels)
+        )
         self.assertEqual(
             len(prepared.channel_intersection) + len(prepared.none_channel_indices),
             len(prepared.required_channels),
@@ -80,26 +112,26 @@ class TestSegmentFrameMatchesSegment(unittest.TestCase):
         for t in range(len(self.stack)):
             with self.subTest(frame=t):
                 np.testing.assert_array_equal(
-                    segment_frame(self.stack[t], prepared), self.reference[t]
+                    segmentation.segment_frame(self.stack[t], prepared), self.reference[t]
                 )
 
     def test_prepared_model_is_reusable_across_calls(self):
         """Reusing one prepared model must not drift between calls."""
         prepared = self._prepare()
-        first = segment_frame(self.stack[0], prepared)
-        second = segment_frame(self.stack[0], prepared)
+        first = segmentation.segment_frame(self.stack[0], prepared)
+        second = segmentation.segment_frame(self.stack[0], prepared)
         np.testing.assert_array_equal(first, second)
 
     def test_frame_shape_is_preserved(self):
         prepared = self._prepare()
-        labels = segment_frame(self.stack[0], prepared)
+        labels = segmentation.segment_frame(self.stack[0], prepared)
         self.assertEqual(labels.shape, self.stack[0].shape[:2])
 
     def test_input_frame_is_not_mutated(self):
         prepared = self._prepare()
         frame = self.stack[0].copy()
         untouched = frame.copy()
-        segment_frame(frame, prepared)
+        segmentation.segment_frame(frame, prepared)
         np.testing.assert_array_equal(frame, untouched)
 
 
@@ -113,14 +145,14 @@ class TestPrepareSegmentationModelContract(unittest.TestCase):
 
     def test_unknown_model_returns_none(self):
         self.assertIsNone(
-            prepare_segmentation_model(
+            segmentation.prepare_segmentation_model(
                 "a-model-that-does-not-exist", channels=self.channels, use_gpu=False
             )
         )
 
     def test_channels_default_to_the_model_requirements(self):
         """channels=None is documented as valid and must not raise."""
-        prepared = prepare_segmentation_model(MODEL, channels=None, use_gpu=False)
+        prepared = segmentation.prepare_segmentation_model(MODEL, channels=None, use_gpu=False)
         self.assertIsNotNone(prepared)
         self.assertEqual(
             list(prepared.channels), list(prepared.required_channels)
@@ -128,7 +160,7 @@ class TestPrepareSegmentationModelContract(unittest.TestCase):
 
     def test_disjoint_channels_are_rejected(self):
         with self.assertRaises(ValueError):
-            prepare_segmentation_model(
+            segmentation.prepare_segmentation_model(
                 MODEL, channels=["not_a_real_channel"], use_gpu=False
             )
 
@@ -152,7 +184,7 @@ class TestChannelMappingAndParameters(unittest.TestCase):
         cls.spatial_calibration = config["spatial_calibration"]
 
     def _prepare(self, **kwargs):
-        return prepare_segmentation_model(
+        return segmentation.prepare_segmentation_model(
             MODEL,
             channels=self.channels,
             spatial_calibration=self.spatial_calibration,
@@ -187,21 +219,61 @@ class TestChannelMappingAndParameters(unittest.TestCase):
         alt = self._prepare(selected_channels=self._remapped_slots(base))
         self.assertFalse(
             np.array_equal(
-                segment_frame(self.stack[0], base),
-                segment_frame(self.stack[0], alt),
+                segmentation.segment_frame(self.stack[0], base),
+                segmentation.segment_frame(self.stack[0], alt),
             )
+        )
+
+    def test_slots_sharing_one_channel_are_all_filled(self):
+        """
+        A mapping may feed one image channel into several of a model's slots.
+
+        The channel-selection dialog allows it, and the pipeline handles it -
+        `_get_img_num_per_channel` gives every slot its own row, so the same frame
+        is simply loaded twice. Matching names instead of walking slots collapsed
+        the duplicates onto the first slot and left the rest black.
+        """
+
+        base = self._prepare()
+        shared = [self.channels[0]] * len(base.required_channels)
+        prepared = self._prepare(selected_channels=shared)
+
+        self.assertEqual(
+            prepared.channel_indices, [0] * len(base.required_channels)
+        )
+        self.assertEqual(len(prepared.none_channel_indices), 0)
+
+    def test_channel_matching_is_case_insensitive_end_to_end(self):
+        """
+        Index resolution and pixel transfer must agree on case.
+
+        `_extract_channel_indices` lowercases both sides, so a slot named in a
+        different case resolves to a real channel; the transfer used to compare
+        names case-sensitively and skip it, leaving a slot that reported as found
+        but was never filled.
+        """
+
+        base = self._prepare()
+        upper = [str(ch).upper() for ch in base.required_channels]
+        prepared = self._prepare(selected_channels=upper)
+
+        self.assertEqual(prepared.channel_indices, base.channel_indices)
+        np.testing.assert_array_equal(
+            segmentation.segment_frame(self.stack[0], prepared),
+            segmentation.segment_frame(self.stack[0], base),
         )
 
     def test_target_cell_size_rescales(self):
         """scale = cell_size_um / target_cell_size_um, as SegmentCellDLProcess does."""
-        prepared = self._prepare(target_cell_size=6.0)
-        cell_size = 13.46  # mcf7_nuc_multimodal, from config_input.json
+        cell_size = _model_config(MODEL)["cell_size_um"]
+        prepared = self._prepare(target_cell_size=cell_size / 2)
         self.assertIsNotNone(prepared.scale_model)
-        self.assertAlmostEqual(prepared.scale_model, cell_size / 6.0, places=6)
+        self.assertAlmostEqual(prepared.scale_model, 2.0, places=6)
 
     def test_matching_cell_sizes_leave_the_scale_alone(self):
         """No rescaling when the images already match the training size."""
-        self.assertIsNone(self._prepare(target_cell_size=13.46).scale_model)
+        cell_size = _model_config(MODEL)["cell_size_um"]
+        self.assertIsNone(self._prepare(target_cell_size=cell_size).scale_model)
 
     def test_stardist_model_reports_no_cellpose_parameters(self):
         prepared = self._prepare()
@@ -209,18 +281,18 @@ class TestChannelMappingAndParameters(unittest.TestCase):
         self.assertIsNone(prepared.diameter)
 
 
+@_requires_cellpose()
 class TestCellposeModelPreparation(unittest.TestCase):
     """Cellpose model loading, which was broken on Windows."""
 
-    CELLPOSE_MODEL = "CP_cyto3"
     # CP_cyto3 declares ['fluorescenceuv', 'None'], which no real experiment
     # has, so it can only be reached through an explicit mapping.
     EXPERIMENT_CHANNELS = ["brightfield_channel", "live_nuclei_channel"]
     MAPPING = ["live_nuclei_channel", "None"]
 
     def _prepare(self, **kwargs):
-        return prepare_segmentation_model(
-            self.CELLPOSE_MODEL,
+        return segmentation.prepare_segmentation_model(
+            CELLPOSE_MODEL,
             channels=self.EXPERIMENT_CHANNELS,
             spatial_calibration=0.3112,
             use_gpu=False,
@@ -255,11 +327,175 @@ class TestCellposeModelPreparation(unittest.TestCase):
         self.assertEqual(prepared.cellprob_threshold, 0.25)
         self.assertEqual(prepared.flow_threshold, 0.6)
 
+    def test_config_defaults_survive_an_override(self):
+        """
+        The model's own values stay reachable after a caller overrides them.
+
+        The napari panel reuses one prepared model across parameter edits, and a
+        field cleared back to blank has to mean "the model's value" - which it can
+        only restore if the prepared model still remembers it.
+        """
+
+        overridden = self._prepare(
+            diameter=12.0, cellprob_threshold=0.25, flow_threshold=0.6
+        )
+        stored = _model_config(CELLPOSE_MODEL)
+        self.assertEqual(
+            overridden.config_defaults["diameter"], stored["diameter"]
+        )
+        self.assertEqual(
+            overridden.config_defaults["cellprob_threshold"],
+            stored["cellprob_threshold"],
+        )
+        self.assertEqual(
+            overridden.config_defaults["flow_threshold"], stored["flow_threshold"]
+        )
+
     def test_segment_frame_runs_with_a_cellpose_model(self):
         prepared = self._prepare()
         frame = np.random.default_rng(0).random((64, 64, 2)) * 100
-        labels = segment_frame(frame, prepared)
+        labels = segmentation.segment_frame(frame, prepared)
         self.assertEqual(labels.shape, (64, 64))
+
+
+class TestSegmentHonoursTheStoredConfiguration(unittest.TestCase):
+    """
+    ``segment()`` now reads the same model settings the pipeline reads.
+
+    That is a deliberate behaviour change (see the changelog): the mapping and the
+    cell size live in the model directory, which is shared across experiments, so
+    these pin both halves of it - that the stored values are picked up, and that an
+    explicit argument still wins so a caller can opt out.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        img = imread(TEST_IMAGE_FILENAME)
+        cls.stack = np.moveaxis([img, img], 1, -1)
+        with open(TEST_CONFIG_FILENAME) as config_file:
+            config = json.load(config_file)
+        cls.channels = config["channels"]
+        cls.spatial_calibration = config["spatial_calibration"]
+
+    def test_segment_passes_the_overrides_through(self):
+        """
+        `segment()` must reach the same masks as the two halves it wraps.
+
+        The arguments only exist so a caller can pin the behaviour rather than
+        inherit whatever the model directory happens to hold, so they are worth
+        nothing unless they actually arrive at `prepare_segmentation_model`.
+        """
+
+        config = _model_config(MODEL)
+        mapping = list(config["channels"])
+        target = config["cell_size_um"] / 2
+
+        labels = segmentation.segment(
+            self.stack,
+            MODEL,
+            channels=self.channels,
+            spatial_calibration=self.spatial_calibration,
+            use_gpu=False,
+            selected_channels=mapping,
+            target_cell_size=target,
+        )
+
+        prepared = segmentation.prepare_segmentation_model(
+            MODEL,
+            channels=self.channels,
+            spatial_calibration=self.spatial_calibration,
+            use_gpu=False,
+            selected_channels=mapping,
+            target_cell_size=target,
+        )
+        self.assertAlmostEqual(prepared.scale_model, 2.0, places=6)
+        np.testing.assert_array_equal(
+            labels[0], segmentation.segment_frame(self.stack[0], prepared)
+        )
+
+    def test_stored_selected_channels_are_honoured(self):
+        """A mapping written into config_input.json reaches the prepared model."""
+
+        model_path = segmentation.locate_segmentation_model(MODEL)
+        config_path = os.path.join(model_path, "config_input.json")
+        with open(config_path) as config_file:
+            original = config_file.read()
+
+        config = json.loads(original)
+        mapping = [str(ch).upper() for ch in config["channels"]]
+        config["selected_channels"] = mapping
+        try:
+            with open(config_path, "w") as config_file:
+                json.dump(config, config_file)
+
+            prepared = segmentation.prepare_segmentation_model(
+                MODEL,
+                channels=self.channels,
+                spatial_calibration=self.spatial_calibration,
+                use_gpu=False,
+            )
+            self.assertEqual(list(prepared.required_channels), mapping)
+
+            # ...and an explicit argument still wins over what is stored.
+            pinned = segmentation.prepare_segmentation_model(
+                MODEL,
+                channels=self.channels,
+                spatial_calibration=self.spatial_calibration,
+                use_gpu=False,
+                selected_channels=list(config["channels"]),
+            )
+            self.assertEqual(
+                list(pinned.required_channels), list(config["channels"])
+            )
+        finally:
+            with open(config_path, "w") as config_file:
+                config_file.write(original)
+
+
+class TestGpuVisibility(unittest.TestCase):
+    """
+    ``CUDA_VISIBLE_DEVICES`` must be put back the way it was found.
+
+    Preparing a model used to set it and leave it set, so one CPU-only call from
+    the GUI pinned the whole process to the CPU for the rest of the session.
+    """
+
+    def setUp(self):
+        self.original = os.environ.get("CUDA_VISIBLE_DEVICES")
+
+    def tearDown(self):
+        if self.original is None:
+            os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        else:
+            os.environ["CUDA_VISIBLE_DEVICES"] = self.original
+
+    def test_existing_value_is_restored(self):
+        os.environ["CUDA_VISIBLE_DEVICES"] = "3"
+        with segmentation._gpu_visibility(False):
+            self.assertEqual(os.environ["CUDA_VISIBLE_DEVICES"], "-1")
+        self.assertEqual(os.environ["CUDA_VISIBLE_DEVICES"], "3")
+
+    def test_absent_value_is_left_absent(self):
+        os.environ.pop("CUDA_VISIBLE_DEVICES", None)
+        with segmentation._gpu_visibility(True):
+            self.assertEqual(os.environ["CUDA_VISIBLE_DEVICES"], "0")
+        self.assertNotIn("CUDA_VISIBLE_DEVICES", os.environ)
+
+    def test_restored_even_when_loading_raises(self):
+        os.environ["CUDA_VISIBLE_DEVICES"] = "3"
+        with self.assertRaises(RuntimeError):
+            with segmentation._gpu_visibility(False):
+                raise RuntimeError("model failed to load")
+        self.assertEqual(os.environ["CUDA_VISIBLE_DEVICES"], "3")
+
+    def test_preparing_a_model_does_not_leak_the_setting(self):
+        os.environ["CUDA_VISIBLE_DEVICES"] = "3"
+        with open(TEST_CONFIG_FILENAME) as config_file:
+            channels = json.load(config_file)["channels"]
+        segmentation.prepare_segmentation_model(
+            MODEL, channels=channels, use_gpu=False
+        )
+        self.assertEqual(os.environ["CUDA_VISIBLE_DEVICES"], "3")
 
 
 if __name__ == "__main__":

--- a/tests/test_segment_frame.py
+++ b/tests/test_segment_frame.py
@@ -349,6 +349,34 @@ class TestPipelineAgreesOnTheTrainedCellSize(unittest.TestCase):
         self.assertIsNone(process.cell_size)
         self.assertIsNone(process.target_cell_size)
 
+    def test_a_non_positive_target_is_refused_rather_than_divided_by(self):
+        """
+        A size that cannot be one must not reach the scale.
+
+        `segment()` raises on these, and the channel dialog no longer writes
+        one, so only a configuration saved by an earlier build still carries
+        them. Zero used to raise ZeroDivisionError once the run had started, and
+        a negative flipped the scale; both now fall back to the calibration-only
+        scale, which is what the model declaring no size at all does.
+        """
+
+        calibration = 0.3112
+        for target in (0.0, -12.0):
+            with self.subTest(target=target):
+                config = dict(_model_config(CELLPOSE_MODEL))
+                config["target_cell_size_um"] = target
+
+                process = self._process_with(config)
+                self.assertIsNone(process.target_cell_size)
+
+                process.spatial_calibration = calibration
+                process.detect_rescaling()
+                self.assertAlmostEqual(
+                    process.scale,
+                    calibration / config["spatial_calibration"],
+                    places=6,
+                )
+
 
 @_requires_cellpose()
 @_requires_cellpose()

--- a/tests/test_segment_frame.py
+++ b/tests/test_segment_frame.py
@@ -209,5 +209,58 @@ class TestChannelMappingAndParameters(unittest.TestCase):
         self.assertIsNone(prepared.diameter)
 
 
+class TestCellposeModelPreparation(unittest.TestCase):
+    """Cellpose model loading, which was broken on Windows."""
+
+    CELLPOSE_MODEL = "CP_cyto3"
+    # CP_cyto3 declares ['fluorescenceuv', 'None'], which no real experiment
+    # has, so it can only be reached through an explicit mapping.
+    EXPERIMENT_CHANNELS = ["brightfield_channel", "live_nuclei_channel"]
+    MAPPING = ["live_nuclei_channel", "None"]
+
+    def _prepare(self, **kwargs):
+        return prepare_segmentation_model(
+            self.CELLPOSE_MODEL,
+            channels=self.EXPERIMENT_CHANNELS,
+            spatial_calibration=0.3112,
+            use_gpu=False,
+            selected_channels=self.MAPPING,
+            **kwargs,
+        )
+
+    def test_cellpose_model_loads(self):
+        """
+        Regression: the Cellpose branch derived the model name as
+        ``model_path.split("/")[-2]``. locate_segmentation_model returns an
+        os.sep-joined path, so on Windows the split yields a single element and
+        the index raised IndexError -- no Cellpose model could be prepared at all.
+        """
+        prepared = self._prepare()
+        self.assertIsNotNone(prepared)
+        self.assertEqual(prepared.model_type, "cellpose")
+        self.assertIsNotNone(prepared.model)
+        self.assertEqual(list(prepared.required_channels), self.MAPPING)
+
+    def test_cellpose_parameters_come_from_the_config(self):
+        prepared = self._prepare()
+        self.assertIsNotNone(prepared.diameter)
+        self.assertIsNotNone(prepared.cellprob_threshold)
+        self.assertIsNotNone(prepared.flow_threshold)
+
+    def test_cellpose_parameters_can_be_overridden(self):
+        prepared = self._prepare(
+            diameter=12.0, cellprob_threshold=0.25, flow_threshold=0.6
+        )
+        self.assertEqual(prepared.diameter, 12.0)
+        self.assertEqual(prepared.cellprob_threshold, 0.25)
+        self.assertEqual(prepared.flow_threshold, 0.6)
+
+    def test_segment_frame_runs_with_a_cellpose_model(self):
+        prepared = self._prepare()
+        frame = np.random.default_rng(0).random((64, 64, 2)) * 100
+        labels = segment_frame(frame, prepared)
+        self.assertEqual(labels.shape, (64, 64))
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_segment_frame.py
+++ b/tests/test_segment_frame.py
@@ -379,7 +379,6 @@ class TestPipelineAgreesOnTheTrainedCellSize(unittest.TestCase):
 
 
 @_requires_cellpose()
-@_requires_cellpose()
 class TestRescalingInvariance(unittest.TestCase):
     """
     Pixel size, trained cell size and target cell size must agree.
@@ -607,6 +606,7 @@ class TestRescalingInvariance(unittest.TestCase):
         self.assertAlmostEqual(scale, both, places=6)
 
 
+@_requires_cellpose()
 class TestCellposeModelPreparation(unittest.TestCase):
     """Cellpose model loading, which was broken on Windows."""
 

--- a/tests/test_segment_frame.py
+++ b/tests/test_segment_frame.py
@@ -133,5 +133,81 @@ class TestPrepareSegmentationModelContract(unittest.TestCase):
             )
 
 
+class TestChannelMappingAndParameters(unittest.TestCase):
+    """
+    The channel mapping and inference parameters the napari panel exposes.
+
+    ``segment()`` used to ignore ``selected_channels`` and ``target_cell_size_um``
+    while ``SegmentCellDLProcess`` honoured both, so the library and the pipeline
+    produced different masks for the same model. These pin the aligned behaviour.
+    """
+
+    @classmethod
+    def setUpClass(cls):
+        img = imread(TEST_IMAGE_FILENAME)
+        cls.stack = np.moveaxis([img, img, img], 1, -1)
+        with open(TEST_CONFIG_FILENAME) as config_file:
+            config = json.load(config_file)
+        cls.channels = config["channels"]
+        cls.spatial_calibration = config["spatial_calibration"]
+
+    def _prepare(self, **kwargs):
+        return prepare_segmentation_model(
+            MODEL,
+            channels=self.channels,
+            spatial_calibration=self.spatial_calibration,
+            use_gpu=False,
+            **kwargs,
+        )
+
+    def _remapped_slots(self, base):
+        """
+        Feed the model's first slot from a different experiment channel.
+
+        Picking any fixed index would risk landing on the channel that already
+        occupies slot 0, making the "remapping" a no-op that proves nothing.
+        """
+        slots = list(base.required_channels)
+        replacement = next(ch for ch in self.channels if ch != slots[0])
+        slots[0] = replacement
+        return slots
+
+    def test_selected_channels_overrides_the_model_slots(self):
+        base = self._prepare()
+        remapped = self._remapped_slots(base)
+        alt = self._prepare(selected_channels=remapped)
+        self.assertEqual(list(alt.required_channels), remapped)
+        self.assertNotEqual(
+            list(alt.required_channels), list(base.required_channels)
+        )
+
+    def test_remapping_changes_the_masks(self):
+        """A mapping that is not a no-op must actually reach inference."""
+        base = self._prepare()
+        alt = self._prepare(selected_channels=self._remapped_slots(base))
+        self.assertFalse(
+            np.array_equal(
+                segment_frame(self.stack[0], base),
+                segment_frame(self.stack[0], alt),
+            )
+        )
+
+    def test_target_cell_size_rescales(self):
+        """scale = cell_size_um / target_cell_size_um, as SegmentCellDLProcess does."""
+        prepared = self._prepare(target_cell_size=6.0)
+        cell_size = 13.46  # mcf7_nuc_multimodal, from config_input.json
+        self.assertIsNotNone(prepared.scale_model)
+        self.assertAlmostEqual(prepared.scale_model, cell_size / 6.0, places=6)
+
+    def test_matching_cell_sizes_leave_the_scale_alone(self):
+        """No rescaling when the images already match the training size."""
+        self.assertIsNone(self._prepare(target_cell_size=13.46).scale_model)
+
+    def test_stardist_model_reports_no_cellpose_parameters(self):
+        prepared = self._prepare()
+        self.assertEqual(prepared.model_type, "stardist")
+        self.assertIsNone(prepared.diameter)
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_segment_frame.py
+++ b/tests/test_segment_frame.py
@@ -1,0 +1,137 @@
+"""
+Tests for the per-frame segmentation API.
+
+``segment()`` was split into :func:`prepare_segmentation_model` (load the model
+once) and :func:`segment_frame` (run it on one image), so that the napari viewer
+can segment the frame on screen without rebuilding the model. These tests pin
+the property that makes the split safe: composing the two halves must reproduce
+exactly what ``segment()`` returns for the same stack.
+"""
+
+import json
+import os
+import unittest
+
+import numpy as np
+from tifffile import imread
+
+from celldetective.segmentation import (
+    PreparedSegmentationModel,
+    prepare_segmentation_model,
+    segment,
+    segment_frame,
+)
+
+TEST_IMAGE_FILENAME = os.path.join(
+    os.path.dirname(__file__), os.sep.join(["assets", "sample.tif"])
+)
+TEST_CONFIG_FILENAME = os.path.join(
+    os.path.dirname(__file__), os.sep.join(["assets", "sample.json"])
+)
+
+MODEL = "mcf7_nuc_multimodal"
+
+
+class TestSegmentFrameMatchesSegment(unittest.TestCase):
+    """The split halves must reproduce the whole-stack function exactly."""
+
+    @classmethod
+    def setUpClass(cls):
+        img = imread(TEST_IMAGE_FILENAME)
+        # Three identical frames, as in test_segmentation.py.
+        cls.stack = np.moveaxis([img, img, img], 1, -1)
+        with open(TEST_CONFIG_FILENAME) as config_file:
+            config = json.load(config_file)
+        cls.channels = config["channels"]
+        cls.spatial_calibration = config["spatial_calibration"]
+
+        cls.reference = segment(
+            cls.stack,
+            MODEL,
+            channels=cls.channels,
+            spatial_calibration=cls.spatial_calibration,
+            view_on_napari=False,
+            use_gpu=False,
+        )
+
+    def _prepare(self):
+        return prepare_segmentation_model(
+            MODEL,
+            channels=self.channels,
+            spatial_calibration=self.spatial_calibration,
+            use_gpu=False,
+        )
+
+    def test_prepare_returns_a_usable_model(self):
+        prepared = self._prepare()
+        self.assertIsInstance(prepared, PreparedSegmentationModel)
+        self.assertIsNotNone(prepared.model)
+        self.assertIn(prepared.model_type, ("stardist", "cellpose"))
+        self.assertEqual(list(prepared.channels), list(self.channels))
+        # Every channel the model needs is accounted for, either transferred or
+        # explicitly zeroed.
+        self.assertEqual(
+            len(prepared.channel_intersection) + len(prepared.none_channel_indices),
+            len(prepared.required_channels),
+        )
+
+    def test_single_frame_matches_the_stack_result(self):
+        prepared = self._prepare()
+        for t in range(len(self.stack)):
+            with self.subTest(frame=t):
+                np.testing.assert_array_equal(
+                    segment_frame(self.stack[t], prepared), self.reference[t]
+                )
+
+    def test_prepared_model_is_reusable_across_calls(self):
+        """Reusing one prepared model must not drift between calls."""
+        prepared = self._prepare()
+        first = segment_frame(self.stack[0], prepared)
+        second = segment_frame(self.stack[0], prepared)
+        np.testing.assert_array_equal(first, second)
+
+    def test_frame_shape_is_preserved(self):
+        prepared = self._prepare()
+        labels = segment_frame(self.stack[0], prepared)
+        self.assertEqual(labels.shape, self.stack[0].shape[:2])
+
+    def test_input_frame_is_not_mutated(self):
+        prepared = self._prepare()
+        frame = self.stack[0].copy()
+        untouched = frame.copy()
+        segment_frame(frame, prepared)
+        np.testing.assert_array_equal(frame, untouched)
+
+
+class TestPrepareSegmentationModelContract(unittest.TestCase):
+    """Argument handling that the napari widget relies on."""
+
+    @classmethod
+    def setUpClass(cls):
+        with open(TEST_CONFIG_FILENAME) as config_file:
+            cls.channels = json.load(config_file)["channels"]
+
+    def test_unknown_model_returns_none(self):
+        self.assertIsNone(
+            prepare_segmentation_model(
+                "a-model-that-does-not-exist", channels=self.channels, use_gpu=False
+            )
+        )
+
+    def test_channels_default_to_the_model_requirements(self):
+        """channels=None is documented as valid and must not raise."""
+        prepared = prepare_segmentation_model(MODEL, channels=None, use_gpu=False)
+        self.assertIsNotNone(prepared)
+        self.assertEqual(
+            list(prepared.channels), list(prepared.required_channels)
+        )
+
+    def test_disjoint_channels_are_rejected(self):
+        with self.assertRaises(ValueError):
+            prepare_segmentation_model(
+                MODEL, channels=["not_a_real_channel"], use_gpu=False
+            )
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/tests/test_segment_frame.py
+++ b/tests/test_segment_frame.py
@@ -282,6 +282,74 @@ class TestChannelMappingAndParameters(unittest.TestCase):
         self.assertIsNone(prepared.diameter)
 
 
+class TestPipelineAgreesOnTheTrainedCellSize(unittest.TestCase):
+    """
+    A cell size set once must mean the same thing everywhere it is applied.
+
+    The main window writes ``target_cell_size_um`` into the model directory, and
+    three places read it back: ``segment()``, the napari single-frame panel, and
+    the full-position run. The first two go through ``trained_cell_size_um()``,
+    which can work the trained size out for a generalist Cellpose model from its
+    ``diameter`` and ``spatial_calibration``. The pipeline used to insist on a
+    ``cell_size_um`` key instead, which those models do not carry -- so the same
+    setting rescaled the preview and did nothing to the run it was previewing.
+    """
+
+    def _process_with(self, config):
+        """A bare process object carrying `config`, with no position set up."""
+
+        from celldetective.processes.segment_cells import SegmentCellDLProcess
+
+        process = SegmentCellDLProcess.__new__(SegmentCellDLProcess)
+        process.input_config = config
+        process.extract_model_input_parameters()
+        return process
+
+    def test_a_generalist_cellpose_size_reaches_the_pipeline(self):
+        config = dict(_model_config(CELLPOSE_MODEL))
+        self.assertNotIn("cell_size_um", config)
+        config["target_cell_size_um"] = 25.0
+
+        process = self._process_with(config)
+
+        self.assertAlmostEqual(
+            process.cell_size,
+            config["diameter"] * config["spatial_calibration"],
+            places=6,
+        )
+        self.assertEqual(process.target_cell_size, 25.0)
+
+    def test_the_pipeline_scale_matches_the_prepared_model(self):
+        """The two paths must land on the same number, not merely both rescale."""
+
+        config = dict(_model_config(CELLPOSE_MODEL))
+        config["target_cell_size_um"] = 25.0
+        calibration = 0.3112
+
+        process = self._process_with(config)
+        process.spatial_calibration = calibration
+        process.detect_rescaling()
+
+        expected = (
+            calibration / config["spatial_calibration"]
+        ) * (config["diameter"] * config["spatial_calibration"] / 25.0)
+        self.assertAlmostEqual(process.scale, expected, places=6)
+
+    def test_a_model_declaring_no_size_still_rescales_on_calibration_only(self):
+        """Nothing to measure against means no cell-size correction, not a crash."""
+
+        # A real StarDist configuration with the one key that carries the
+        # trained size taken away: a StarDist model states no diameter, so there
+        # is nothing left to work the size out from.
+        config = dict(_model_config(MODEL))
+        config.pop("cell_size_um", None)
+        config["target_cell_size_um"] = 25.0
+
+        process = self._process_with(config)
+        self.assertIsNone(process.cell_size)
+        self.assertIsNone(process.target_cell_size)
+
+
 @_requires_cellpose()
 @_requires_cellpose()
 class TestRescalingInvariance(unittest.TestCase):
@@ -519,15 +587,26 @@ class TestCellposeModelPreparation(unittest.TestCase):
     EXPERIMENT_CHANNELS = ["brightfield_channel", "live_nuclei_channel"]
     MAPPING = ["live_nuclei_channel", "None"]
 
+    # Finer than the images CP_cyto3 was trained on, so every scale below
+    # carries a calibration correction on top of any cell-size correction.
+    SPATIAL_CALIBRATION = 0.3112
+
     def _prepare(self, **kwargs):
         return segmentation.prepare_segmentation_model(
             CELLPOSE_MODEL,
             channels=self.EXPERIMENT_CHANNELS,
-            spatial_calibration=0.3112,
+            spatial_calibration=self.SPATIAL_CALIBRATION,
             use_gpu=False,
             selected_channels=self.MAPPING,
             **kwargs,
         )
+
+    def _calibration_scale(self, config):
+        """
+        The resampling the frame needs on pixel size alone, before any
+        correction for how big the cells are.
+        """
+        return self.SPATIAL_CALIBRATION / config["spatial_calibration"]
 
     def test_cellpose_model_loads(self):
         """
@@ -567,21 +646,30 @@ class TestCellposeModelPreparation(unittest.TestCase):
         config = _model_config(CELLPOSE_MODEL)
         self.assertNotIn("cell_size_um", config)
         trained = config["diameter"] * config["spatial_calibration"]
+        calibration = self._calibration_scale(config)
 
-        # Cells twice the trained size: the frame is halved so they reach the
-        # network at the diameter it was trained on.
+        # Cells twice the trained size: halved on top of the calibration
+        # correction, so they reach the network at the diameter it was
+        # trained on.
         prepared = self._prepare(target_cell_size=2 * trained)
-        self.assertAlmostEqual(prepared.scale_model, 0.5, places=6)
+        self.assertAlmostEqual(prepared.scale_model, 0.5 * calibration, places=6)
 
         # Half the trained size: doubled instead.
         prepared = self._prepare(target_cell_size=trained / 2)
-        self.assertAlmostEqual(prepared.scale_model, 2.0, places=6)
+        self.assertAlmostEqual(prepared.scale_model, 2.0 * calibration, places=6)
 
-    def test_matching_cell_size_leaves_a_generic_cellpose_model_alone(self):
+    def test_matching_cell_size_leaves_only_the_calibration_correction(self):
+        """
+        Cells already at the trained physical size need no correction of their
+        own -- but the frame still carries the model's pixel size, so what is
+        left is the calibration correction, not no rescaling at all.
+        """
         config = _model_config(CELLPOSE_MODEL)
         trained = config["diameter"] * config["spatial_calibration"]
         prepared = self._prepare(target_cell_size=trained)
-        self.assertAlmostEqual(prepared.scale_model, 1.0, places=6)
+        self.assertAlmostEqual(
+            prepared.scale_model, self._calibration_scale(config), places=6
+        )
 
     def test_the_trained_diameter_is_never_rescaled_away(self):
         """

--- a/tests/test_segment_frame.py
+++ b/tests/test_segment_frame.py
@@ -283,6 +283,234 @@ class TestChannelMappingAndParameters(unittest.TestCase):
 
 
 @_requires_cellpose()
+@_requires_cellpose()
+class TestRescalingInvariance(unittest.TestCase):
+    """
+    Pixel size, trained cell size and target cell size must agree.
+
+    Three numbers decide how a frame is resized before it reaches the network,
+    and they are easy to get subtly wrong in a way no unit test on any one of
+    them would catch. The property that ties them together is an invariance: one
+    physical cell, of one size in microns, must arrive at the network at the
+    pixel size it was trained on -- no matter how finely the microscope sampled
+    it, and no matter how big the cells in the sample happen to be.
+
+    So these tests do not check a formula. They put a disc of a known physical
+    diameter into a small synthetic frame, run the real preprocessing, intercept
+    the image on its way into the network, and measure the disc there.
+    """
+
+    MODEL = CELLPOSE_MODEL
+    EXPERIMENT_CHANNELS = ["fluorescenceuv"]
+    MAPPING = ["fluorescenceuv", "None"]
+
+    #: The disc is drawn on a lit background, not on zero. Normalization ignores
+    #: the gray value 0, so a disc on a black field leaves it nothing but the
+    #: disc's own constant interior to stretch, and the frame comes out blank.
+    BACKGROUND = 0.2
+    FOREGROUND = 1.0
+
+    def setUp(self):
+        self.captured = []
+        self._real_inference = segmentation._segment_image_with_cellpose_model
+
+        def spy(img, **kwargs):
+            self.captured.append(np.array(img))
+            return np.zeros(img.shape[:2], dtype=np.uint16)
+
+        segmentation._segment_image_with_cellpose_model = spy
+
+    def tearDown(self):
+        segmentation._segment_image_with_cellpose_model = self._real_inference
+
+    @staticmethod
+    def _frame_with_a_disc(diameter_px, size_px, background, foreground):
+        """A one-channel frame holding a single disc of the given pixel size."""
+        yy, xx = np.mgrid[:size_px, :size_px]
+        centre = (size_px - 1) / 2.0
+        radius = np.sqrt((yy - centre) ** 2 + (xx - centre) ** 2)
+        frame = np.where(radius <= diameter_px / 2.0, foreground, background)
+        return frame.astype(float)[:, :, None]
+
+    @staticmethod
+    def _diameter_of_the_disc(image):
+        """
+        The disc's diameter, in pixels, as it stands in `image`.
+
+        Measured from the area above half of the intensity range rather than by
+        counting a row: rescaling interpolates, so the edge is a ramp a pixel or
+        two wide and the area is the steadier reading.
+        """
+        channel = image[:, :, 0]
+        low, high = float(channel.min()), float(channel.max())
+        area = int(np.count_nonzero(channel > (low + high) / 2.0))
+        return 2.0 * np.sqrt(area / np.pi)
+
+    def _diameter_reaching_the_network(
+        self, spatial_calibration, cell_size_um, background=None
+    ):
+        """
+        Segment one synthetic frame and report the disc size the network saw.
+
+        Parameters
+        ----------
+        spatial_calibration : float
+            Microns per pixel of the imaginary microscope.
+        cell_size_um : float
+            The physical diameter of the disc, which is also what the user would
+            enter as the cell size for these images.
+        background : float, optional
+            The level the disc is drawn on. Defaults to :attr:`BACKGROUND`.
+
+        Returns
+        -------
+        tuple of (float, float)
+            The disc's diameter in pixels as the network received it, and the
+            rescaling factor that was applied to get it there.
+        """
+
+        diameter_px = cell_size_um / spatial_calibration
+        # Wide enough that the disc never touches the border, so nothing is lost
+        # to the edge on the way through.
+        size_px = int(max(64, round(diameter_px * 3)))
+
+        prepared = segmentation.prepare_segmentation_model(
+            self.MODEL,
+            channels=self.EXPERIMENT_CHANNELS,
+            spatial_calibration=spatial_calibration,
+            selected_channels=self.MAPPING,
+            target_cell_size=cell_size_um,
+            use_stored_mapping=False,
+            use_gpu=False,
+        )
+        self.assertIsNotNone(prepared)
+
+        frame = self._frame_with_a_disc(
+            diameter_px,
+            size_px,
+            self.BACKGROUND if background is None else background,
+            self.FOREGROUND,
+        )
+        segmentation.segment_frame(frame, prepared)
+
+        self.assertEqual(len(self.captured), 1)
+        scale = 1.0 if prepared.scale_model is None else prepared.scale_model
+        return self._diameter_of_the_disc(self.captured[0]), scale
+
+    def _trained_diameter_px(self):
+        """The pixel size the model expects its objects at."""
+        return _model_config(self.MODEL)["diameter"]
+
+    def test_the_pixel_size_does_not_change_what_the_network_sees(self):
+        """
+        The same 20 um cell, sampled four ways, arrives at one size.
+
+        A finer pixel size makes the cell wider in the raw image and must shrink
+        the image by exactly as much on the way in.
+        """
+
+        expected = self._trained_diameter_px()
+        for calibration in (0.2, 0.4, 0.5789739776951672, 1.0):
+            with self.subTest(spatial_calibration=calibration):
+                self.setUp()
+                measured, _ = self._diameter_reaching_the_network(calibration, 20.0)
+                self.assertAlmostEqual(measured / expected, 1.0, delta=0.05)
+
+    def test_the_cell_size_does_not_change_what_the_network_sees(self):
+        """
+        Cells of 8, 20 and 40 um, at one pixel size, arrive at one size too.
+
+        This is the leg that a generic Cellpose model could not do at all before
+        it was given a trained size in microns to be rescaled against.
+        """
+
+        expected = self._trained_diameter_px()
+        for cell_size in (8.0, 20.0, 40.0):
+            with self.subTest(cell_size_um=cell_size):
+                self.setUp()
+                measured, _ = self._diameter_reaching_the_network(0.4, cell_size)
+                self.assertAlmostEqual(measured / expected, 1.0, delta=0.05)
+
+    def test_doubling_the_cell_size_halves_the_image(self):
+        """Cells twice as big must be shrunk twice as much, and nothing else."""
+
+        _, scale = self._diameter_reaching_the_network(0.4, 20.0)
+        self.setUp()
+        _, doubled = self._diameter_reaching_the_network(0.4, 40.0)
+        self.assertAlmostEqual(scale / doubled, 2.0, places=6)
+
+    def test_halving_the_pixel_size_halves_the_image(self):
+        """A cell sampled twice as finely must be shrunk twice as much."""
+
+        _, scale = self._diameter_reaching_the_network(0.4, 20.0)
+        self.setUp()
+        _, finer = self._diameter_reaching_the_network(0.2, 20.0)
+        self.assertAlmostEqual(scale / finer, 2.0, places=6)
+
+    def test_the_background_level_cannot_be_what_makes_this_come_out(self):
+        """
+        The rescaling is the same on any background, a black one included.
+
+        Which is the point: the factor is worked out from the pixel size and the
+        two cell sizes alone, and no pixel of the image is ever read to arrive at
+        it. So the level these tests happen to draw on cannot be what produces
+        the invariance above -- it only has to let the disc be measured again
+        afterwards.
+        """
+
+        scales = []
+        for background in (0.0, 0.05, 0.2, 0.5, 0.9):
+            with self.subTest(background=background):
+                self.setUp()
+                _, scale = self._diameter_reaching_the_network(
+                    0.4, 20.0, background=background
+                )
+                scales.append(scale)
+        self.assertEqual(len(set(scales)), 1)
+
+    def test_the_measured_size_does_not_depend_on_the_background(self):
+        """And the disc measures the same size on any background that is lit."""
+
+        expected = self._trained_diameter_px()
+        for background in (0.05, 0.2, 0.5, 0.9):
+            with self.subTest(background=background):
+                self.setUp()
+                measured, _ = self._diameter_reaching_the_network(
+                    0.4, 20.0, background=background
+                )
+                self.assertAlmostEqual(measured / expected, 1.0, delta=0.05)
+
+    def test_a_disc_on_black_is_the_one_background_that_cannot_be_measured(self):
+        """
+        Why :attr:`BACKGROUND` is not zero, pinned rather than left in a comment.
+
+        Normalization ignores the gray value 0, so on a black field the only
+        pixels it has left to stretch are the disc's own constant interior: the
+        low and high percentiles come out equal and the frame reaches the network
+        carrying no disc at all. The rescaling is untouched -- the test above
+        shows the factor is the same -- but there is then nothing to measure, so
+        the disc is drawn on a lit field instead.
+        """
+
+        expected = self._trained_diameter_px()
+        measured, _ = self._diameter_reaching_the_network(0.4, 20.0, background=0.0)
+        self.assertLess(measured, 0.5 * expected)
+
+    def test_the_two_effects_cancel(self):
+        """
+        Cells twice as big, sampled twice as finely, come out where they started.
+
+        The clearest statement that the pixel size and the cell size enter the
+        rescaling the same way: doubling both is the same scene, so the frame
+        must be resized by the same factor.
+        """
+
+        _, scale = self._diameter_reaching_the_network(0.4, 20.0)
+        self.setUp()
+        _, both = self._diameter_reaching_the_network(0.8, 40.0)
+        self.assertAlmostEqual(scale, both, places=6)
+
+
 class TestCellposeModelPreparation(unittest.TestCase):
     """Cellpose model loading, which was broken on Windows."""
 
@@ -327,6 +555,45 @@ class TestCellposeModelPreparation(unittest.TestCase):
         self.assertEqual(prepared.diameter, 12.0)
         self.assertEqual(prepared.cellprob_threshold, 0.25)
         self.assertEqual(prepared.flow_threshold, 0.6)
+
+    def test_generic_cellpose_gets_a_trained_cell_size_from_its_diameter(self):
+        """
+        A generic Cellpose model declares no ``cell_size_um``, so before this it
+        could not be rescaled at all: the correction needs both the trained size
+        and the target, and one of them was always missing. The model does say
+        the same thing in pixels -- ``diameter`` px at its own
+        ``spatial_calibration`` -- so the physical size is that product.
+        """
+        config = _model_config(CELLPOSE_MODEL)
+        self.assertNotIn("cell_size_um", config)
+        trained = config["diameter"] * config["spatial_calibration"]
+
+        # Cells twice the trained size: the frame is halved so they reach the
+        # network at the diameter it was trained on.
+        prepared = self._prepare(target_cell_size=2 * trained)
+        self.assertAlmostEqual(prepared.scale_model, 0.5, places=6)
+
+        # Half the trained size: doubled instead.
+        prepared = self._prepare(target_cell_size=trained / 2)
+        self.assertAlmostEqual(prepared.scale_model, 2.0, places=6)
+
+    def test_matching_cell_size_leaves_a_generic_cellpose_model_alone(self):
+        config = _model_config(CELLPOSE_MODEL)
+        trained = config["diameter"] * config["spatial_calibration"]
+        prepared = self._prepare(target_cell_size=trained)
+        self.assertAlmostEqual(prepared.scale_model, 1.0, places=6)
+
+    def test_the_trained_diameter_is_never_rescaled_away(self):
+        """
+        Rescaling the frame is the whole mechanism, so the diameter handed to
+        Cellpose stays the one the network was trained on.
+        """
+        config = _model_config(CELLPOSE_MODEL)
+        trained = config["diameter"] * config["spatial_calibration"]
+        for target in (None, trained, 2 * trained, trained / 2):
+            with self.subTest(target=target):
+                prepared = self._prepare(target_cell_size=target)
+                self.assertEqual(prepared.diameter, config["diameter"])
 
     def test_config_defaults_survive_an_override(self):
         """

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -302,3 +302,57 @@ class TestMakeJsonSafe(unittest.TestCase):
 
 if __name__ == "__main__":
     unittest.main()
+
+
+class TestSegmentationModelListing(unittest.TestCase):
+    """
+    Listing the models must not rewrite the model tree unless asked to.
+
+    ``get_segmentation_models_list`` creates the category directory and deletes any
+    local model folder without a ``config_input.json``. That is reasonable upkeep
+    for the settings dialogs that own the model tree, but the napari panel lists
+    the models just to fill a dropdown when a viewer opens - deleting folders is
+    not a side effect an ordinary "what is available?" should have.
+    """
+
+    def setUp(self):
+        from celldetective.utils.model_getters import get_segmentation_models_list
+
+        self.list_models = get_segmentation_models_list
+        _, self.modelpath = self.list_models(
+            mode="targets", return_path=True, cleanup=False
+        )
+
+    def test_a_model_without_a_config_survives_a_read_only_listing(self):
+        import os
+        from shutil import rmtree
+
+        broken = os.path.join(self.modelpath, "a-model-with-no-config")
+        os.makedirs(broken, exist_ok=True)
+        try:
+            listed = self.list_models(mode="targets", cleanup=False)
+            self.assertTrue(os.path.isdir(broken))
+            # It is still not offered: a model with no input configuration
+            # cannot be loaded, whether or not it is left on disk.
+            self.assertNotIn("a-model-with-no-config", listed)
+        finally:
+            if os.path.isdir(broken):
+                rmtree(broken)
+
+    def test_cleanup_still_removes_it_when_asked(self):
+        import os
+
+        broken = os.path.join(self.modelpath, "a-model-with-no-config")
+        os.makedirs(broken, exist_ok=True)
+        self.list_models(mode="targets", cleanup=True)
+        self.assertFalse(os.path.isdir(broken))
+
+    def test_an_unknown_category_is_not_created_by_a_read_only_listing(self):
+        import os
+
+        # "target" (singular) is not a real category; the panel normalises it, but
+        # a listing must not conjure a directory for whatever it is handed.
+        stray = os.path.join(os.path.dirname(self.modelpath.rstrip(os.sep)), "segmentation_not-a-population")
+        self.assertFalse(os.path.isdir(stray))
+        self.list_models(mode="not-a-population", cleanup=False)
+        self.assertFalse(os.path.isdir(stray))


### PR DESCRIPTION
## Summary

Adds a **Segment frame** panel to the napari segmentation viewer, so a model can be run on the frame currently on screen without leaving the viewer or launching a full-stack run.

Getting there required splitting `segment()` into a reusable setup/inference pair, extracting the main window's channel-selection rows into a shared widget, and fixing several pre-existing bugs that the panel made easy to reach. The branch also carries a behaviour-preserving performance pass over a handful of hot array/dataframe helpers, and adds a `CHANGELOG.md`.

## The panel — `celldetective/napari/frame_segmentation.py` (new, 1117 lines)

`FrameSegmentationPanel`, docked at the top of the segmentation viewer's right-hand panel:

- **Model picker** listing the models available for the population being segmented, plus the generic ones. A model that has not been downloaded yet is offered too and fetched on the first run.
- **One dropdown per model input slot** (the shared `ModelChannelSelection` widget, see below), seeded from the `selected_channels` mapping persisted in `config_input.json`, falling back to a name match. This is what makes models like `CP_cyto3` — which declares `['fluorescenceuv', 'None']`, a name no real experiment uses — usable at all.
- **The parameters the selected model actually takes**: cell probability and flow threshold for Cellpose, and cell size (µm) for every model whose trained object size can be worked out. The fields rebuild when the model changes. The Cellpose *diameter* is deliberately not exposed: it is the size the network was trained to see, and it is the image that moves.
- **Replace / merge** for the resulting labels. Merging offsets the incoming labels past those already drawn so the two sets cannot collide, and refuses to write labels that would not fit the layer's integer type rather than wrapping round.
- The write is pushed onto the labels layer's undo history, so **Ctrl+Z** works like any other edit.
- A prepared model is **cached per (model, channel mapping, cell size)**, bounded to 2 entries, so repeated runs only pay for inference.

Edits made in the panel stay local to the napari session and are never written back to `config_input.json`. If the panel fails to build for any reason, it is logged and the viewer still opens without it.

### Off the GUI thread

Segmentation ran on the Qt main thread, freezing napari for the whole run — a dozen seconds or more on the first click, while the model loads. The work now runs in a `QThread`, with an indeterminate progress bar and a phase label; inputs are disabled while a run is in flight and the button becomes **Cancel**.

Measured with the event loop pumped during a run: **395 timer ticks over 12.8 s**, against none before.

Cancellation is cooperative and checked between phases — neither StarDist nor Cellpose exposes a hook to interrupt a forward pass. `closeEvent` cancels and detaches, so a run cannot outlive the panel, and a result that lands after the viewer is gone is dropped. Declining napari's "are you sure you want to close?" prompt leaves the panel intact.

## Shared channel-selection rows — `celldetective/gui/base/model_channel_selection.py` (new)

`ModelChannelSelection` is one dropdown per model input slot, seeded in decreasing order of specificity: the mapping already saved for the model, then a name match, then `None`. The main window's `SegModelParamsWidget` and `SignalModelParamsWidget` and the napari panel now all build their rows from it, so a model's inputs are mapped the same way wherever it is run from. `process_block.py` reads the mapping back through `channel_selection.selected_channels()`.

`SegModelParamsWidget` also now offers the **cell size** row for any model with a trained size — including a generalist Cellpose model, which states that size in pixels (`diameter` × `spatial_calibration`) rather than in microns — and builds the field only when it is shown, so `set_selected_channels_for_segmentation` no longer writes its placeholder 40 µm as though the user had asked for it. The row reopens on the size last saved.

## Library changes — `celldetective/segmentation.py`

`segment()` is split into two halves so the loaded model can be reused frame by frame:

- `prepare_segmentation_model(...) -> PreparedSegmentationModel | None` — reads `config_input.json`, resolves the channel mapping, estimates the rescaling factor and instantiates the StarDist/Cellpose model.
- `segment_frame(frame, prepared) -> ndarray` — channel transfer, normalization, rescaling and inference for one image, rescaling the labels back to the frame's original dimensions.

`segment()` keeps its signature and behaviour and is now a thin wrapper over the two.

New optional arguments on both: `selected_channels`, `target_cell_size`, `diameter` (explicit overrides) and `use_stored_mapping` (opt into the `selected_channels` / `target_cell_size_um` entries the GUI writes into the model directory). These are opt-in because that directory is installed once and shared by every experiment.

`channels=None` now falls back to the model's own required channels, as the docstring has always claimed; previously it raised a `TypeError`.

**`CUDA_VISIBLE_DEVICES`** is now set only inside a `_gpu_visibility` context around model construction and inference and restored afterwards, instead of being left pinned for the lifetime of the process. `segment_frame` re-applies the device choice its model was prepared with.

## Bug fixes (all pre-existing on `dev`)

- **Cellpose models could not be prepared on Windows.** The model name was derived as `model_path.split("/")[-2]`, but `locate_segmentation_model` builds that path with `os.sep`, so the split returned a single element and the index raised `IndexError`. `model_name` is now passed straight through, as `SegmentCellDLProcess` already did.
- **Crash when no model is available** — `locate_segmentation_model` returning `None` is now handled instead of propagating.
- **A channel mapping feeding one experiment channel into several input slots** no longer leaves all but the first slot black; matching is now consistently case-insensitive instead of resolving indices case-insensitively and transferring pixels case-sensitively.
- **An interrupted download no longer shadows the copy on Zenodo forever**: `locate_segmentation_model` skips a local directory with no `config_input.json`.
- **Listing the models no longer rewrites the model tree**: `get_segmentation_models_list(cleanup=False)` neither creates the category directory nor deletes local folders.
- **StarDist GPU probe**: `stardist.gputools_available()` only checks that `gputools` imports; a real OpenCL device is now probed so NMS falls back to CPU instead of failing at predict time.
- `prepare_segmentation_model` no longer raises `KeyError` on a Cellpose config that omits `diameter` / `cellprob_threshold` / `flow_threshold` when the caller passes them explicitly.
- A cell size of zero is rejected with a message naming the field rather than failing with `float division by zero`.
- **A cell size set in the main window now reaches the full-position run** for a generalist Cellpose model too. The pipeline read the trained size from a `cell_size_um` key those models do not carry, so the same setting rescaled the napari preview and `segment()` while the run it was previewing ignored it. `SegmentCellDLProcess` now goes through `trained_cell_size_um()` like everything else.
- **Closing the viewer mid-run no longer strands the worker.** Detaching the panel's slots cleared the whole `finished` signal, taking the worker's own `_LIVE_WORKERS.discard` and `deleteLater` with it, so a run still in flight kept its thread, the image stack and the loaded network alive for the rest of the session. The four panel slots are now disconnected by name.
- **A cell size of zero, blank or negative is refused at every point it can be entered or read**: the field takes a validator bottom, the channel dialog turns away a blank or zero instead of writing it to the configuration, and the pipeline ignores a non-positive `target_cell_size_um` left behind by an earlier build rather than dividing by it — zero raised `ZeroDivisionError` once the run had started and a negative flipped the scale.

## Performance pass (behaviour-preserving)

Vectorised hot loops in helpers used by measurement and mask post-processing, checked against the `dev` implementations on randomised inputs:

- `utils/maths.py` — `derivative`, `magnitude_velocity`, `orientation` vectorised; `differentiate_per_track` / `velocity_per_track` fill a preallocated array instead of repeated `.loc` writes, and handle an empty table.
- `utils/mask_cleaning.py` — `auto_correct_masks` renumbers via `bincount` + LUT in one pass and no longer mutates the caller's array; `relabel_segmentation` pre-groups the table by frame, rewrites each frame through a LUT, and uses a **shared** lock (the old `with threading.Lock():` created a fresh lock each time and synchronised nothing).
- `utils/masks.py` — `contour_of_instance_segmentation` skips the exterior EDT and the feature transform for inner-only contours; `create_patch_mask` accepts tuples and numpy scalars.
- `utils/normalization.py` — `numexpr` imported once, redundant copies and percentile passes removed.
- `regionprops/_regionprops.py` — channel-name lookup table and signature cache.
- `utils/image_loaders.py` — `locate_labels` uses a name-to-index dict instead of repeated `list.index`.

## Docs

`docs/source/segment.rst` documents the single-frame panel and the cell-size row. New `CHANGELOG.md` (Keep a Changelog format) covering this branch plus 1.5.3 / 1.5.2 / 1.5.1 retroactively.

## Tests

~101 new tests, all passing:

- `tests/test_segment_frame.py` (new, 41) — pins the property that makes the split safe: composing `prepare_segmentation_model` + `segment_frame` must reproduce exactly what `segment()` returns for the same stack. Plus the contract of the new entry points: model reuse across calls, frame shape preserved, input frame not mutated, unknown model returns `None`, channels default to the model requirements, disjoint channels rejected, `selected_channels` / `target_cell_size` overrides, and the Cellpose Windows regression. `TestPipelineAgreesOnTheTrainedCellSize` pins the parity fix above: the pipeline and the prepared model must land on the same scale for the same setting, not merely both rescale.
- `tests/gui/test_frame_segmentation_panel.py` (new, 39) — panel construction, model switching, channel/parameter rows, threading, cancellation, close handling, cache eviction, label writing and merging.
- `tests/gui/test_model_channel_selection.py` (new, 16) and `tests/gui/test_segmentation_model_params.py` (new, 5) — the shared widget's seeding rules and the cell-size row.
- `tests/test_utils.py` (+3) — listing the models must not rewrite the model tree.
- `tests/test_partial_install.py` — reworked so a module reloaded with its extras mocked away is reloaded again on the way out, instead of leaving the rest of the run talking to a degraded module.

## Files

```
CHANGELOG.md                                                |  273 +++++
celldetective/gui/base/model_channel_selection.py           |  180 ++++
celldetective/gui/gui_utils.py                              |   15 +-
celldetective/gui/process_block.py                          |   28 +-
celldetective/gui/settings/_event_detection_model_params.py |   48 +-
celldetective/gui/settings/_segmentation_model_params.py    |   84 +-
celldetective/napari/frame_segmentation.py                  | 1126 ++++++++++
celldetective/napari/utils.py                               |   16 +
celldetective/processes/segment_cells.py                    |   32 +-
celldetective/regionprops/_regionprops.py                   |   41 +-
celldetective/segmentation.py                               |  606 ++++++--
celldetective/utils/image_loaders.py                        |   11 +-
celldetective/utils/mask_cleaning.py                        |  109 +-
celldetective/utils/masks.py                                |   46 +-
celldetective/utils/maths.py                                |   91 +-
celldetective/utils/model_getters.py                        |   23 +-
celldetective/utils/model_loaders.py                        |   78 ++
celldetective/utils/normalization.py                        |  117 +-
celldetective/utils/stardist_utils/__init__.py              |   39 +
docs/source/segment.rst                                     |   61 ++
tests/ (6 files)                                            | 1809 ++++++++
26 files changed, 4414 insertions(+), 419 deletions(-)
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QFGabfNAxnHnA9Wi8ZK1xM

